### PR TITLE
fix: L2 msg auth on L1

### DIFF
--- a/contracts/src/FastBridgeReceiverOnEthereum.sol
+++ b/contracts/src/FastBridgeReceiverOnEthereum.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 /**
- *  @authors: [@jaybuidl, @shotaronowhere, @hrishibhat, @adi274]
+ *  @authors: [@jaybuidl, @shotaronowhere, @hrishibhat]
  *  @reviewers: []
  *  @auditors: []
  *  @bounties: []
@@ -38,7 +38,8 @@ contract FastBridgeReceiverOnEthereum is IFastBridgeReceiver, ISafeBridgeReceive
 
     function isSentBySafeBridge() internal view virtual override returns (bool) {
         IOutbox outbox = IOutbox(inbox.bridge().activeOutbox());
-        return msg.sender == address(outbox) && outbox.l2ToL1Sender() == safeBridgeSender;
+        address bridge = address(inbox.bridge());
+        return msg.sender == address(bridge) && outbox.l2ToL1Sender() == safeBridgeSender;
     }
 
     /**

--- a/contracts/src/FastBridgeReceiverOnGnosis.sol
+++ b/contracts/src/FastBridgeReceiverOnGnosis.sol
@@ -115,7 +115,7 @@ contract FastBridgeReceiverOnGnosis is IFastBridgeReceiver, ISafeBridgeReceiver 
 
         uint256 epochNow = block.timestamp / epochPeriod;
         // allow claim about current or previous epoch
-        require(_epoch == epochNow || _epoch == epochNow + 1, "Invalid Epoch.");
+        require(_epoch == epochNow || _epoch == epochNow - 1, "Invalid Epoch.");
         require(claims[_epoch].bridger == address(0), "Claim already made for most recent finalized epoch.");
 
         claims[_epoch] = Claim({

--- a/contracts/src/FastBridgeReceiverOnPolygon.sol
+++ b/contracts/src/FastBridgeReceiverOnPolygon.sol
@@ -109,7 +109,7 @@ contract FastBridgeReceiverOnPolygon is FxBaseChildTunnel, IFastBridgeReceiver, 
 
         uint256 epochNow = block.timestamp / epochPeriod;
         // allow claim about current or previous epoch
-        require(_epoch == epochNow || _epoch == epochNow + 1, "Invalid Epoch");
+        require(_epoch == epochNow || _epoch == epochNow - 1, "Invalid Epoch");
         require(claims[_epoch].bridger == address(0), "Claim already made for most recent finalized epoch.");
 
         claims[_epoch] = Claim({


### PR DESCRIPTION
fixing this bug L2 msg authentication bug.

I saw this reviewing arbitrum's contracts, but you can see [openzeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/crosschain/arbitrum/LibArbitrumL1.sol) as a reference as well.