### PR TITLE
Use a recent non-floating version of Solidity

### DIFF
--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -17,7 +17,7 @@ dotenv.config();
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.9",
+    version: "0.8.18",
     settings: {
       optimizer: {
         enabled: true,

--- a/contracts/src/ArbToEth/VeaInboxArbToEth.sol
+++ b/contracts/src/ArbToEth/VeaInboxArbToEth.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../canonical/arbitrum/IArbSys.sol";
 import "../interfaces/IVeaInbox.sol";
@@ -214,11 +214,7 @@ contract VeaInboxArbToEth is IVeaInbox {
 
         require(epochSend < epochNow, "Can only send past epoch snapshot.");
 
-        bytes memory data = abi.encodeWithSelector(
-            IVeaOutbox.resolveDisputedClaim.selector,
-            epochSend,
-            snapshots[epochSend]
-        );
+        bytes memory data = abi.encodeCall(IVeaOutbox.resolveDisputedClaim, (epochSend, snapshots[epochSend]));
 
         bytes32 ticketID = bytes32(ARB_SYS.sendTxToL1(veaOutbox, data));
 
@@ -229,7 +225,7 @@ contract VeaInboxArbToEth is IVeaInbox {
      * @dev Sends heartbeat to VeaOutbox.
      */
     function sendHeartbeat() external virtual {
-        bytes memory data = abi.encodeWithSelector(IVeaOutbox.heartbeat.selector, block.timestamp);
+        bytes memory data = abi.encodeCall(IVeaOutbox.heartbeat, block.timestamp);
 
         bytes32 ticketID = bytes32(ARB_SYS.sendTxToL1(veaOutbox, data));
 

--- a/contracts/src/ArbToEth/VeaOutboxArbToEth.sol
+++ b/contracts/src/ArbToEth/VeaOutboxArbToEth.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../canonical/arbitrum/IInbox.sol";
 import "../canonical/arbitrum/IOutbox.sol";

--- a/contracts/src/ArbToEth/VeaOutboxArbToEthCensorshipTest.sol
+++ b/contracts/src/ArbToEth/VeaOutboxArbToEthCensorshipTest.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../canonical/arbitrum/IInbox.sol";
 import "../canonical/arbitrum/IOutbox.sol";

--- a/contracts/src/ArbToGnosis/RouterArbToGnosis.sol
+++ b/contracts/src/ArbToGnosis/RouterArbToGnosis.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../canonical/gnosis-chain/IAMB.sol";
 import "../canonical/arbitrum/IInbox.sol";
@@ -65,7 +65,7 @@ contract RouterArbToGnosis is IRouter {
         require(msg.sender == address(bridge), "Not from bridge.");
         require(IOutbox(bridge.activeOutbox()).l2ToL1Sender() == sender, "Sender only.");
 
-        bytes memory data = abi.encodeWithSelector(IVeaOutbox.resolveDisputedClaim.selector, epoch, stateroot);
+        bytes memory data = abi.encodeCall(IVeaOutbox.resolveDisputedClaim, (epoch, stateroot));
 
         // replace maxGasPerTx with safe level for production deployment
         bytes32 ticketID = amb.requireToPassMessage(receiver, data, amb.maxGasPerTx());

--- a/contracts/src/ArbToGnosis/VeaInboxArbToGnosis.sol
+++ b/contracts/src/ArbToGnosis/VeaInboxArbToGnosis.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../canonical/arbitrum/IArbSys.sol";
 import "../interfaces/IVeaInbox.sol";
@@ -208,7 +208,7 @@ contract VeaInboxArbToGnosis is IVeaInbox {
 
         require(epochSend < epochNow, "Cannot send stateroot for current or future epoch.");
 
-        bytes memory data = abi.encodeWithSelector(IRouter.route.selector, epochSend, snapshots[epochSend]);
+        bytes memory data = abi.encodeCall(IRouter.route, (epochSend, snapshots[epochSend]));
 
         bytes32 ticketID = bytes32(ARB_SYS.sendTxToL1(routerArbToGnosis, data));
 
@@ -219,7 +219,7 @@ contract VeaInboxArbToGnosis is IVeaInbox {
      * @dev Sends heartbeat to VeaOutbox.
      */
     function sendHeartbeat() external virtual {
-        bytes memory data = abi.encodeWithSelector(IVeaOutbox.heartbeat.selector, block.timestamp);
+        bytes memory data = abi.encodeCall(IVeaOutbox.heartbeat, block.timestamp);
 
         bytes32 ticketID = bytes32(ARB_SYS.sendTxToL1(routerArbToGnosis, data));
 

--- a/contracts/src/ArbToGnosis/VeaOutboxArbToGnosis.sol
+++ b/contracts/src/ArbToGnosis/VeaOutboxArbToGnosis.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../canonical/gnosis-chain/IAMB.sol";
 import "../interfaces/IVeaOutbox.sol";

--- a/contracts/src/canonical/arbitrum/AddressAliasHelper.sol
+++ b/contracts/src/canonical/arbitrum/AddressAliasHelper.sol
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-pragma solidity >=0.7.0;
+pragma solidity 0.8.18;
 
 library AddressAliasHelper {
     uint160 constant offset = uint160(0x1111000000000000000000000000000000001111);

--- a/contracts/src/canonical/arbitrum/IArbRetryableTx.sol
+++ b/contracts/src/canonical/arbitrum/IArbRetryableTx.sol
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-pragma solidity >=0.7.0;
+pragma solidity 0.8.18;
 
 /**
  * @title precompiled contract in every Arbitrum chain for retryable transaction related data retrieval and interactions. Exists at 0x000000000000000000000000000000000000006E

--- a/contracts/src/canonical/arbitrum/IArbSys.sol
+++ b/contracts/src/canonical/arbitrum/IArbSys.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity >=0.7.0;
+pragma solidity 0.8.18;
 
 /**
  * @title Precompiled contract that exists in every Arbitrum chain at address(100), 0x0000000000000000000000000000000000000064. Exposes a variety of system-level functionality.

--- a/contracts/src/canonical/arbitrum/IInbox.sol
+++ b/contracts/src/canonical/arbitrum/IInbox.sol
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-pragma solidity >=0.7.0;
+pragma solidity 0.8.18;
 
 interface IInbox {
     function sendL2Message(bytes calldata messageData) external returns (uint256);

--- a/contracts/src/canonical/arbitrum/IOutbox.sol
+++ b/contracts/src/canonical/arbitrum/IOutbox.sol
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-pragma solidity >=0.7.0;
+pragma solidity 0.8.18;
 
 interface IOutbox {
     event OutboxEntryCreated(uint256 indexed batchNum, uint256 outboxIndex, bytes32 outputRoot, uint256 numInBatch);

--- a/contracts/src/canonical/gnosis-chain/IAMB.sol
+++ b/contracts/src/canonical/gnosis-chain/IAMB.sol
@@ -2,14 +2,10 @@
 // Complete IAMB Interface
 // https://github.com/poanetwork/tokenbridge-contracts/blob/master/contracts/interfaces/IAMB.sol
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 interface IAMB {
-    function requireToPassMessage(
-        address _contract,
-        bytes memory _data,
-        uint256 _gas
-    ) external returns (bytes32);
+    function requireToPassMessage(address _contract, bytes memory _data, uint256 _gas) external returns (bytes32);
 
     function maxGasPerTx() external view returns (uint256);
 
@@ -29,11 +25,7 @@ interface IAMB {
 
     function failedMessageSender(bytes32 _messageId) external view returns (address);
 
-    function requireToConfirmMessage(
-        address _contract,
-        bytes memory _data,
-        uint256 _gas
-    ) external returns (bytes32);
+    function requireToConfirmMessage(address _contract, bytes memory _data, uint256 _gas) external returns (bytes32);
 
     function requireToGetInformation(bytes32 _requestSelector, bytes memory _data) external returns (bytes32);
 

--- a/contracts/src/canonical/polygon/FxBaseChildTunnel.sol
+++ b/contracts/src/canonical/polygon/FxBaseChildTunnel.sol
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: MIT
 // https://github.com/fx-portal/contracts/blob/main/contracts/tunnel/FxBaseChildTunnel.sol
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 // IFxMessageProcessor represents interface to process message
 interface IFxMessageProcessor {
-    function processMessageFromRoot(
-        uint256 stateId,
-        address rootMessageSender,
-        bytes calldata data
-    ) external;
+    function processMessageFromRoot(uint256 stateId, address rootMessageSender, bytes calldata data) external;
 }
 
 /**
@@ -40,11 +36,7 @@ abstract contract FxBaseChildTunnel is IFxMessageProcessor {
         fxRootTunnel = _fxRootTunnel;
     }
 
-    function processMessageFromRoot(
-        uint256 stateId,
-        address rootMessageSender,
-        bytes calldata data
-    ) external override {
+    function processMessageFromRoot(uint256 stateId, address rootMessageSender, bytes calldata data) external override {
         require(msg.sender == fxChild, "FxBaseChildTunnel: INVALID_SENDER");
         _processMessageFromRoot(stateId, rootMessageSender, data);
     }
@@ -71,9 +63,5 @@ abstract contract FxBaseChildTunnel is IFxMessageProcessor {
      * @param sender root message sender
      * @param message bytes message that was sent from Root Tunnel
      */
-    function _processMessageFromRoot(
-        uint256 stateId,
-        address sender,
-        bytes memory message
-    ) internal virtual;
+    function _processMessageFromRoot(uint256 stateId, address sender, bytes memory message) internal virtual;
 }

--- a/contracts/src/canonical/polygon/FxBaseRootTunnel.sol
+++ b/contracts/src/canonical/polygon/FxBaseRootTunnel.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // https://github.com/fx-portal/contracts/blob/main/contracts/tunnel/FxBaseRootTunnel.sol
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import {RLPReader} from "./lib/RLPReader.sol";
 import {MerklePatriciaProof} from "./lib/MerklePatriciaProof.sol";

--- a/contracts/src/canonical/polygon/lib/ExitPayloadReader.sol
+++ b/contracts/src/canonical/polygon/lib/ExitPayloadReader.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import {RLPReader} from "./RLPReader.sol";
 
@@ -28,11 +28,7 @@ library ExitPayloadReader {
     }
 
     // copy paste of private copy() from RLPReader to avoid changing of existing contracts
-    function copy(
-        uint256 src,
-        uint256 dest,
-        uint256 len
-    ) private pure {
+    function copy(uint256 src, uint256 dest, uint256 len) private pure {
         if (len == 0) return;
 
         // copy as many word sizes as possible
@@ -46,7 +42,7 @@ library ExitPayloadReader {
         }
 
         // left over bytes. Mask is used to remove unwanted bytes from the word
-        uint256 mask = 256**(WORD_SIZE - len) - 1;
+        uint256 mask = 256 ** (WORD_SIZE - len) - 1;
         assembly {
             let srcpart := and(mload(src), not(mask)) // zero out src
             let destpart := and(mload(dest), mask) // retrieve the bytes

--- a/contracts/src/canonical/polygon/lib/Merkle.sol
+++ b/contracts/src/canonical/polygon/lib/Merkle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 library Merkle {
     function checkMembership(
@@ -12,7 +12,7 @@ library Merkle {
         uint256 proofHeight = proof.length / 32;
         // Proof of size n means, height of the tree is n+1.
         // In a tree of height n+1, max #leafs possible is 2 ^ n
-        require(index < 2**proofHeight, "Leaf index is too big");
+        require(index < 2 ** proofHeight, "Leaf index is too big");
 
         bytes32 proofElement;
         bytes32 computedHash = leaf;

--- a/contracts/src/canonical/polygon/lib/MerklePatriciaProof.sol
+++ b/contracts/src/canonical/polygon/lib/MerklePatriciaProof.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import {RLPReader} from "./RLPReader.sol";
 

--- a/contracts/src/canonical/polygon/lib/RLPReader.sol
+++ b/contracts/src/canonical/polygon/lib/RLPReader.sol
@@ -2,7 +2,7 @@
  * @author Hamdi Allam hamdi.allam97@gmail.com
  * Please reach out with any questions or concerns
  */
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 library RLPReader {
     uint8 constant STRING_SHORT_START = 0x80;
@@ -309,11 +309,7 @@ library RLPReader {
      * @param dest Pointer to destination
      * @param len Amount of memory to copy from the source
      */
-    function copy(
-        uint256 src,
-        uint256 dest,
-        uint256 len
-    ) private pure {
+    function copy(uint256 src, uint256 dest, uint256 len) private pure {
         if (len == 0) return;
 
         // copy as many word sizes as possible
@@ -329,7 +325,7 @@ library RLPReader {
         if (len == 0) return;
 
         // left over bytes. Mask is used to remove unwanted bytes from the word
-        uint256 mask = 256**(WORD_SIZE - len) - 1;
+        uint256 mask = 256 ** (WORD_SIZE - len) - 1;
 
         assembly {
             let srcpart := and(mload(src), not(mask)) // zero out src

--- a/contracts/src/interfaces/IReceiverGateway.sol
+++ b/contracts/src/interfaces/IReceiverGateway.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "./IVeaOutbox.sol";
 

--- a/contracts/src/interfaces/IRouter.sol
+++ b/contracts/src/interfaces/IRouter.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 interface IRouter {
     /**

--- a/contracts/src/interfaces/ISenderGateway.sol
+++ b/contracts/src/interfaces/ISenderGateway.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "./IVeaInbox.sol";
 

--- a/contracts/src/interfaces/IVeaInbox.sol
+++ b/contracts/src/interfaces/IVeaInbox.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 interface IVeaInbox {
     /**

--- a/contracts/src/interfaces/IVeaOutbox.sol
+++ b/contracts/src/interfaces/IVeaOutbox.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 interface IVeaOutbox {
     /**

--- a/contracts/src/libraries/gnosis-chain/Bytes.sol
+++ b/contracts/src/libraries/gnosis-chain/Bytes.sol
@@ -1,6 +1,6 @@
 //https://github.com/poanetwork/tokenbridge-contracts/blob/master/contracts/libraries/Bytes.sol
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 /**
  * @title Bytes

--- a/contracts/src/merkle/MerkleProof.sol
+++ b/contracts/src/merkle/MerkleProof.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 /**
  *  @title MerkleProof

--- a/contracts/src/merkle/MerkleTree.sol
+++ b/contracts/src/merkle/MerkleTree.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 /**
  *  @title MerkleTree

--- a/contracts/src/test/ArbToEth/VeaInboxMockArbToEth.sol
+++ b/contracts/src/test/ArbToEth/VeaInboxMockArbToEth.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../ArbToEth/VeaInboxArbToEth.sol";
 
@@ -25,10 +25,9 @@ contract VeaInboxMockArbToEth is VeaInboxArbToEth {
     function sendSnapshot(uint256 _epochSnapshot) external override {
         uint256 epoch = uint256(block.timestamp) / epochPeriod;
         require(_epochSnapshot <= epoch, "Epoch in the future.");
-        bytes memory data = abi.encodeWithSelector(
-            IVeaOutbox.resolveDisputedClaim.selector,
-            _epochSnapshot,
-            snapshots[_epochSnapshot]
+        bytes memory data = abi.encodeCall(
+            IVeaOutbox.resolveDisputedClaim,
+            (_epochSnapshot, snapshots[_epochSnapshot])
         );
 
         bytes32 ticketID = bytes32(arbSys.sendTxToL1(veaOutbox, data));

--- a/contracts/src/test/ArbToEth/VeaOutboxMockArbToEth.sol
+++ b/contracts/src/test/ArbToEth/VeaOutboxMockArbToEth.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../ArbToEth/VeaOutboxArbToEth.sol";
 import "../../canonical/arbitrum/IArbSys.sol";

--- a/contracts/src/test/bridge-mocks/arbitrum/ArbSysMock.sol
+++ b/contracts/src/test/bridge-mocks/arbitrum/ArbSysMock.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../../canonical/arbitrum/IArbSys.sol";
 

--- a/contracts/src/test/bridge-mocks/arbitrum/BridgeMock.sol
+++ b/contracts/src/test/bridge-mocks/arbitrum/BridgeMock.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../../canonical/arbitrum/IInbox.sol";
 

--- a/contracts/src/test/bridge-mocks/arbitrum/InboxMock.sol
+++ b/contracts/src/test/bridge-mocks/arbitrum/InboxMock.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../../canonical/arbitrum/IInbox.sol";
 

--- a/contracts/src/test/bridge-mocks/arbitrum/OutboxMock.sol
+++ b/contracts/src/test/bridge-mocks/arbitrum/OutboxMock.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../../canonical/arbitrum/IOutbox.sol";
 

--- a/contracts/src/test/bridge-mocks/gnosis/MockAMB.sol
+++ b/contracts/src/test/bridge-mocks/gnosis/MockAMB.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // https://github.com/poanetwork/tokenbridge-contracts/blob/master/contracts/mocks/AMBMock.sol
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../../canonical/gnosis-chain/IAMB.sol";
 import "../../../libraries/gnosis-chain/Bytes.sol";

--- a/contracts/src/test/gateways/IReceiverGatewayMock.sol
+++ b/contracts/src/test/gateways/IReceiverGatewayMock.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../interfaces/IReceiverGateway.sol";
 

--- a/contracts/src/test/gateways/ReceiverGatewayMock.sol
+++ b/contracts/src/test/gateways/ReceiverGatewayMock.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "./IReceiverGatewayMock.sol";
 

--- a/contracts/src/test/gateways/SenderGatewayMock.sol
+++ b/contracts/src/test/gateways/SenderGatewayMock.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "./IReceiverGatewayMock.sol";
 import "../../interfaces/ISenderGateway.sol";

--- a/contracts/src/test/merkle/MerkleProofExposed.sol
+++ b/contracts/src/test/merkle/MerkleProofExposed.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../merkle/MerkleProof.sol";
 
@@ -23,11 +23,7 @@ contract MerkleProofExposed is MerkleProof {
      *  @param leaf The leaf to validate membership in merkle tree.
      *  @param merkleRoot The root of the merkle tree.
      */
-    function validateProof(
-        bytes32[] memory proof,
-        bytes32 leaf,
-        bytes32 merkleRoot
-    ) public pure returns (bool) {
+    function validateProof(bytes32[] memory proof, bytes32 leaf, bytes32 merkleRoot) public pure returns (bool) {
         return _validateProof(proof, leaf, merkleRoot);
     }
 }

--- a/contracts/src/test/merkle/MerkleTreeExposed.sol
+++ b/contracts/src/test/merkle/MerkleTreeExposed.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import "../../merkle/MerkleTree.sol";
 


### PR DESCRIPTION
Resolves #107 and implements https://github.com/kleros/builder-baseline/issues/1

Make use of the new [abi.encodeCall()](https://blog.soliditylang.org/2021/12/20/solidity-0.8.11-release-announcement/) to benefit from type checking.