### PR TITLE
fix: reset pages shown when filter applied

### DIFF
--- a/veascan-web/src/App.tsx
+++ b/veascan-web/src/App.tsx
@@ -46,7 +46,6 @@ const App = () => {
 
   const handlePageChange = useCallback(
     (newPage: number) => {
-      console.log("data", data);
       if (newPage > currentPage)
         pushPageTracking({
           timestamp: data?.snapshots.at(-1)?.[0].timestamp,

--- a/veascan-web/src/App.tsx
+++ b/veascan-web/src/App.tsx
@@ -40,8 +40,10 @@ const App = () => {
   const { fromChain, toChain, statusFilter } = useFiltersContext();
 
   useEffect(() => {
-    clearPageTracking();
-    setCurrentPage(1);
+    if (currentPage !== 1) {
+      clearPageTracking();
+      setCurrentPage(1);
+    }
   }, [fromChain, toChain, statusFilter]);
 
   const handlePageChange = useCallback(

--- a/veascan-web/src/App.tsx
+++ b/veascan-web/src/App.tsx
@@ -1,12 +1,13 @@
-import React, { useState, useCallback } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import styled from "styled-components";
 import { useList } from "react-use";
 import { StandardPagination } from "@kleros/ui-components-library";
 import Layout from "components/Layout";
 import SnapshotAccordion from "components/SnapshotAccordion";
 import TxFilterHeader from "components/TxFilterHeader";
-import { useSnapshots, getSnapshotId } from "hooks/useSnapshots";
+import { getSnapshotId, useSnapshots } from "hooks/useSnapshots";
 import { mapDataForAccordion } from "utils/mapDataForAccordion";
+import { useFiltersContext } from "./contexts/FiltersContext";
 
 const SNAPSHOTS_PER_PAGE = 5;
 
@@ -24,15 +25,28 @@ const App = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [
     pageTracking,
-    { push: pushPageTracking, removeAt: removeAtPageTracking },
+    {
+      push: pushPageTracking,
+      removeAt: removeAtPageTracking,
+      clear: clearPageTracking,
+    },
   ] = useList<IPageTracking>();
   const { data } = useSnapshots(
     pageTracking.at(-1)?.shownSnapshots,
     pageTracking.at(-1)?.timestamp,
     SNAPSHOTS_PER_PAGE
   );
+
+  const { fromChain, toChain, statusFilter } = useFiltersContext();
+
+  useEffect(() => {
+    clearPageTracking();
+    setCurrentPage(1);
+  }, [fromChain, toChain, statusFilter]);
+
   const handlePageChange = useCallback(
     (newPage: number) => {
+      console.log("data", data);
       if (newPage > currentPage)
         pushPageTracking({
           timestamp: data?.snapshots.at(-1)?.[0].timestamp,


### PR DESCRIPTION
fixed bug that doesn't reset to first page when filters applied