### PR TITLE
ci: set Java version

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -28,6 +28,14 @@ jobs:
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          # Set the JDK version to use
+          java-version: '17'
+          distribution: 'temurin'
+
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@9c0534dd12d09f22d69fbb301a1955249e49d910 # master
         env:


### PR DESCRIPTION
- Added a specific Java version(17) to the GitHub Actions workflow to resolve the version mismatch error during SonarCloud analysis in the CI pipeline.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on upgrading the JDK version to 17 for SonarCloud analysis.

### Detailed summary
- Upgraded JDK version to 17 for SonarCloud analysis
- Set up JDK 17 using `actions/setup-java@v4`
- Specified JDK distribution as 'temurin'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced CI/CD pipeline by adding a step to set up JDK 17 for improved compatibility with Java projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->