### PR TITLE
feat(veascan-subgraph): outbox verification event handling

### DIFF
--- a/veascan-subgraph-outbox/subgraph.yaml
+++ b/veascan-subgraph-outbox/subgraph.yaml
@@ -30,4 +30,6 @@ dataSources:
           handler: handleMessageRelayed
         - event: Verified(uint256)
           handler: handleVerified
+        - event: VerificationStarted(indexed uint256)
+          handler: handleVerificationStarted
       file: ./src/VeaOutbox.ts


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the handling of verification events in the `veascan-subgraph-outbox`. It introduces a new event handler for `VerificationStarted` and updates the existing `handleVerified` function to change how claims are marked as verified.

### Detailed summary
- Added new event `VerificationStarted` in `subgraph.yaml`.
- Introduced `handleVerificationStarted` function to handle `VerificationStarted` events.
- In `handleVerificationStarted`, added logic to find the corresponding claim and create a `Verification` entity.
- Updated `handleVerified` to set `claim.verified` and `claim.honest` to `true` instead of creating a new `Verification` entity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->