### PR TITLE
fix(relayer): changes variable typo

### DIFF
--- a/relayer-cli/src/utils/ethers.ts
+++ b/relayer-cli/src/utils/ethers.ts
@@ -51,10 +51,10 @@ function getVeaOutbox(veaOutboxAddress: string, privateKey: string, web3Provider
   switch (bridge.chain) {
     case "sepolia":
     case "mainnet":
-      return VeaOutboxArbToEth__factory.connect(veaInboxAddress, getWallet(privateKey, web3ProviderURL));
+      return VeaOutboxArbToEth__factory.connect(veaOutboxAddress, getWallet(privateKey, web3ProviderURL));
     case "chiado":
     case "gnosis":
-      return VeaOutboxArbToGnosis__factory.connect(veaInboxAddress, getWallet(privateKey, web3ProviderURL));
+      return VeaOutboxArbToGnosis__factory.connect(veaOutboxAddress, getWallet(privateKey, web3ProviderURL));
     default:
       throw new Error(`Unsupported chainId: ${chainId}`);
   }


### PR DESCRIPTION
After some refactor, it seems like the `getVeaOutbox` function kept references to a `veaInboxAddress` which does not exist in the function scope.

This PR changes `veaInboxAddress` to `veaOutboxAddress` in the `getVeaOutbox` function.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `ethers.ts` file to correct the address being connected to the `VeaOutboxArbToEth__factory` and `VeaOutboxArbToGnosis__factory` by replacing `veaInboxAddress` with `veaOutboxAddress` for the `sepolia`, `mainnet`, `chiado`, and `gnosis` cases.

### Detailed summary
- Changed `veaInboxAddress` to `veaOutboxAddress` in the `sepolia` case for `VeaOutboxArbToEth__factory`.
- Changed `veaInboxAddress` to `veaOutboxAddress` in the `mainnet` case for `VeaOutboxArbToEth__factory`.
- Changed `veaInboxAddress` to `veaOutboxAddress` in the `chiado` case for `VeaOutboxArbToGnosis__factory`.
- Changed `veaInboxAddress` to `veaOutboxAddress` in the `gnosis` case for `VeaOutboxArbToGnosis__factory`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected variable name for outbox address in key functions to ensure accurate connections to outbox contracts.
	- Maintained existing error handling for unsupported chain IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->