### PR TITLE
fix: deep stack call mocks removed

### DIFF
--- a/contracts/src/test/ArbToGnosis/VeaInboxArbToGnosisMock.sol
+++ b/contracts/src/test/ArbToGnosis/VeaInboxArbToGnosisMock.sol
@@ -36,4 +36,8 @@ contract VeaInboxArbToGnosisMock is VeaInboxArbToGnosis {
 
         emit SnapshotSent(_epoch, ticketID);
     }
+
+    function getCallData(uint256 _epoch, uint256 _gasLimit, Claim memory _claim) external view returns (bytes memory) {
+        return abi.encodeCall(IRouterToGnosis.route, (_epoch, snapshots[_epoch], _gasLimit, _claim));
+    }
 }

--- a/contracts/src/test/bridge-mocks/arbitrum/ArbSysMockWithBridge.sol
+++ b/contracts/src/test/bridge-mocks/arbitrum/ArbSysMockWithBridge.sol
@@ -13,15 +13,14 @@ import "./BridgeMock.sol";
 
 contract ArbSysMockWithBridge is IArbSys {
     BridgeMock public immutable bridge;
-
+    event L2toL1Transaction(address caller, address destination);
     constructor(BridgeMock _bridge) {
         bridge = _bridge;
     }
 
-    function sendTxToL1(
-        address destination,
-        bytes calldata calldataForL1
-    ) external payable returns (uint256 _withdrawal_ID) {
-        return bridge.executeL1Message(destination, calldataForL1);
+    // Mock function to test L2 to L1 transaction
+    function sendTxToL1(address destination, bytes calldata calldataForL1) external payable returns (uint256) {
+        emit L2toL1Transaction(msg.sender, destination);
+        return 1;
     }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `ArbToGnosis` bridge functionality by adding a new method to retrieve call data and modifying the `sendTxToL1` function to emit an event. It also updates test cases to utilize the new mock contract and ensure proper integration.

### Detailed summary
- Added `getCallData` function in `VeaInboxArbToGnosisMock` to encode call data.
- Introduced `L2toL1Transaction` event in `ArbSysMockWithBridge`.
- Modified `sendTxToL1` to emit `L2toL1Transaction` and return a constant value.
- Updated tests to use `VeaInboxArbToGnosisMock` instead of `VeaInboxArbToGnosis`.
- Included hardcoded `TICKET_ID` in tests.
- Adjusted snapshot emission expectations in tests to use `TICKET_ID`.
- Refactored claim object creation for clarity in tests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new public function `getCallData` for retrieving encoded call data.
  - Added a new event `L2toL1Transaction` to log transactions from Layer 2 to Layer 1.

- **Bug Fixes**
  - Updated `sendTxToL1` functionality to emit the new event instead of interacting with the bridge.

- **Tests**
  - Enhanced integration tests with a new mock contract and updated event assertions.
  - Refined logic for handling disputes and withdrawals in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->