### PR TITLE
chore: upgrade upload artifact version

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -64,7 +64,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the `actions/upload-artifact` used in the `.github/workflows/scorecards.yml` file from version `v3.1.2` to `v4.6.1`, ensuring the workflow utilizes the latest features and fixes from the action.

### Detailed summary
- Updated `actions/upload-artifact` from `v3.1.2` to `v4.6.1` in the `.github/workflows/scorecards.yml` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated our automation workflow to the latest integration version to enhance performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->