### PR TITLE
Chore/updated relayer encoding fix

### DIFF
--- a/relayer-cli/src/utils/proof.ts
+++ b/relayer-cli/src/utils/proof.ts
@@ -5,6 +5,9 @@ interface MessageSentData {
   to: {
     id: string;
   };
+  msgSender: {
+    id: string;
+  };
   data: string;
 }
 
@@ -34,12 +37,15 @@ const getMessageDataToRelay = async (
                 to {
                     id
                 }
+                msgSender {
+                    id
+                }
                 data
                 }
             }`
     )) as MessageSentsDataResponse;
 
-    return [result[`messageSents`][0].to.id, result[`messageSents`][0].data];
+    return [result[`messageSents`][0].to.id, result[`messageSents`][0].msgSender.id, result[`messageSents`][0].data];
   } catch (e) {
     console.log(e);
     return undefined;

--- a/relayer-cli/src/utils/relay.test.ts
+++ b/relayer-cli/src/utils/relay.test.ts
@@ -61,7 +61,7 @@ describe("relay", () => {
       fetchVeaOutbox = jest.fn().mockReturnValue(veaOutboxMock);
 
       fetchProofAtCount = jest.fn().mockResolvedValue([]);
-      fetchMessageDataToRelay = jest.fn().mockResolvedValue(["to", "data"]);
+      fetchMessageDataToRelay = jest.fn().mockResolvedValue(["to", "from", "data"]);
 
       mockWait = jest.fn().mockResolvedValue("receipt");
       mockBatchSend = jest.fn().mockResolvedValue({ wait: mockWait });

--- a/relayer-cli/src/utils/relay.ts
+++ b/relayer-cli/src/utils/relay.ts
@@ -59,8 +59,8 @@ const relay = async (chainId: number, nonce: number, network: Network) => {
     getMessageDataToRelay(chainId, veaInboxAddress, nonce),
   ]);
   if (!messageData) throw new DataError("relay message data");
-  const [to, data] = messageData;
-  const txn = await veaOutbox.sendMessage(proof, nonce, to, data);
+  const [to, from, data] = messageData;
+  const txn = await veaOutbox.sendMessage(proof, nonce, to, from, data);
   const receipt = await txn.wait();
   return receipt;
 };
@@ -127,10 +127,10 @@ const relayBatch = async ({
         fetchProofAtCount(chainId, nonce, count, veaInboxAddress),
         fetchMessageDataToRelay(chainId, veaInboxAddress, nonce),
       ]);
-      const [to, data] = messageData;
+      const [to, from, data] = messageData;
       try {
-        await veaOutbox.sendMessage.staticCall(proof, nonce, to, data);
-        const callData = veaOutbox.interface.encodeFunctionData("sendMessage", [proof, nonce, to, data]);
+        await veaOutbox.sendMessage.staticCall(proof, nonce, to, from, data);
+        const callData = veaOutbox.interface.encodeFunctionData("sendMessage", [proof, nonce, to, from, data]);
         datas.push(callData);
         targets.push(veaOutboxAddress);
         values.push(0);
@@ -142,6 +142,7 @@ const relayBatch = async ({
       }
     }
     if (batchMessages > 0) {
+      console.log(targets, datas);
       const gasLimit = await batcher.batchSend.estimateGas(targets, values, datas);
       const tx = await batcher.batchSend(targets, values, datas, { gasLimit });
       const receipt = await tx.wait();
@@ -193,9 +194,9 @@ const relayAllFrom = async (
         getProofAtCount(chainId, x, count, veaInboxAddress),
         getMessageDataToRelay(chainId, veaInboxAddress, x),
       ]);
-      const [to, data] = messageData;
+      const [to, from, data] = messageData;
 
-      const callData = veaOutbox.interface.encodeFunctionData("sendMessage", [proof, x, to, data]);
+      const callData = veaOutbox.interface.encodeFunctionData("sendMessage", [proof, x, to, from, data]);
       datas.push(callData);
       targets.push(veaContracts[network].veaOutbox.address);
       values.push(0);

--- a/relayer-subgraph-inbox/src/vea-inbox.ts
+++ b/relayer-subgraph-inbox/src/vea-inbox.ts
@@ -30,12 +30,12 @@ export function handleMessageSent(event: MessageSentEvent): void {
   let _to = new ByteArray(20);
   for (let i = 0; i < 20; i++) _to[i] = msgData[i + 8];
 
-  let dataLength = msgData.length - 28;
-  let _data = new ByteArray(dataLength);
-  for (let i = 0; i < dataLength; i++) _data[i] = msgData[i + 28];
-
   let _msgSender = new ByteArray(20);
-  for (let i = 0; i < 20; i++) _msgSender[i] = _data[i + 16];
+  for (let i = 0; i < 20; i++) _msgSender[i] = msgData[i + 28];
+
+  let dataLength = msgData.length - 48;
+  let _data = new ByteArray(dataLength);
+  for (let i = 0; i < dataLength; i++) _data[i] = msgData[i + 48];
 
   entity.inbox = event.address;
   entity.nonce = BigInt.fromByteArray(_nonce.reverse() as ByteArray);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the message data structure and its handling within the relay system, specifically adding a `msgSender` field to messages and updating related functions to accommodate this change.

### Detailed summary
- Updated `fetchMessageDataToRelay` to return `["to", "from", "data"]` instead of `["to", "data"]`.
- Added `msgSender` to the message data structure.
- Modified `getMessageDataToRelay` to return `msgSender.id`.
- Adjusted function calls to use `from` in `sendMessage` methods.
- Updated data extraction logic in `vea-inbox.ts` to accommodate new data length and structure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added per-receiver allowlists for relaying messages, with optional “allow all” mode.
  - Sample gateways support sending and receiving dynamic array payloads.

- Breaking Changes
  - Inbox message API simplified: sendMessage now takes (to, data) with selector embedded in data.
  - Outbox message relay now requires the sender address; message hashing includes the sender.

- CLI
  - Relayer updated to fetch and pass the sender address; all relay paths use the new signature.

- Subgraph
  - Updated message decoding to the new payload layout (separate sender field).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->