### PR TITLE
Feat/snapshot period

### DIFF
--- a/validator-cli/src/consts/bridgeRoutes.ts
+++ b/validator-cli/src/consts/bridgeRoutes.ts
@@ -30,7 +30,7 @@ type RouteConfigs = {
   deposit: bigint;
 };
 
-export enum Network {
+enum Network {
   DEVNET = "devnet",
   TESTNET = "testnet",
 }
@@ -39,7 +39,7 @@ const arbToEthConfigs: { [key in Network]: RouteConfigs } = {
   [Network.DEVNET]: {
     veaInbox: veaInboxArbToEthDevnet,
     veaOutbox: veaOutboxArbToEthDevnet,
-    epochPeriod: 1800,
+    epochPeriod: 300,
     deposit: BigInt("1000000000000000000"),
   },
   [Network.TESTNET]: {
@@ -54,7 +54,7 @@ const arbToGnosisConfigs: { [key in Network]: RouteConfigs } = {
   [Network.DEVNET]: {
     veaInbox: veaInboxArbToGnosisDevnet,
     veaOutbox: veaOutboxArbToGnosisDevnet,
-    epochPeriod: 1800,
+    epochPeriod: 300,
     deposit: BigInt("100000000000000000"),
   },
   [Network.TESTNET]: {
@@ -66,7 +66,7 @@ const arbToGnosisConfigs: { [key in Network]: RouteConfigs } = {
   },
 };
 
-export const bridges: { [chainId: number]: Bridge } = {
+const bridges: { [chainId: number]: Bridge } = {
   11155111: {
     chain: "sepolia",
     minChallengePeriod: 10800,
@@ -87,10 +87,16 @@ export const bridges: { [chainId: number]: Bridge } = {
   },
 };
 
+// For the remaining time in an epoch the bot should save snapshots
+const snapshotSavingPeriod = {
+  [Network.DEVNET]: 90, // 1m 30s
+  [Network.TESTNET]: 600, // 10 mins
+};
+
 const getBridgeConfig = (chainId: number): Bridge => {
   const bridge = bridges[chainId];
   if (!bridge) throw new Error(`Bridge not found for chain`);
   return bridges[chainId];
 };
 
-export { getBridgeConfig, Bridge };
+export { bridges, getBridgeConfig, Bridge, Network, snapshotSavingPeriod };

--- a/validator-cli/src/consts/bridgeRoutes.ts
+++ b/validator-cli/src/consts/bridgeRoutes.ts
@@ -11,7 +11,7 @@ import veaOutboxArbToGnosisDevnet from "@kleros/vea-contracts/deployments/chiado
 import veaInboxArbToGnosisTestnet from "@kleros/vea-contracts/deployments/arbitrumSepolia/VeaInboxArbToGnosisTestnet.json";
 import veaOutboxArbToGnosisTestnet from "@kleros/vea-contracts/deployments/chiado/VeaOutboxArbToGnosisTestnet.json";
 import veaRouterArbToGnosisTestnet from "@kleros/vea-contracts/deployments/sepolia/RouterArbToGnosisTestnet.json";
-interface Bridge {
+export interface Bridge {
   chain: string;
   minChallengePeriod: number;
   sequencerDelayLimit: number;
@@ -99,4 +99,4 @@ const getBridgeConfig = (chainId: number): Bridge => {
   return bridges[chainId];
 };
 
-export { bridges, getBridgeConfig, Bridge, Network, snapshotSavingPeriod };
+export { bridges, getBridgeConfig, Network, snapshotSavingPeriod };

--- a/validator-cli/src/helpers/snapshot.test.ts
+++ b/validator-cli/src/helpers/snapshot.test.ts
@@ -1,7 +1,6 @@
-import { Network } from "../consts/bridgeRoutes";
+import { Network, snapshotSavingPeriod } from "../consts/bridgeRoutes";
 import { isSnapshotNeeded, saveSnapshot } from "./snapshot";
 import { MockEmitter } from "../utils/emitter";
-import { snapshotSavingPeriod } from "../consts/bridgeRoutes";
 
 describe("snapshot", () => {
   let veaInbox: any;

--- a/validator-cli/src/helpers/snapshot.test.ts
+++ b/validator-cli/src/helpers/snapshot.test.ts
@@ -1,6 +1,7 @@
 import { Network } from "../consts/bridgeRoutes";
 import { isSnapshotNeeded, saveSnapshot } from "./snapshot";
 import { MockEmitter } from "../utils/emitter";
+import { snapshotSavingPeriod } from "../consts/bridgeRoutes";
 
 describe("snapshot", () => {
   let veaInbox: any;
@@ -184,7 +185,8 @@ describe("snapshot", () => {
       expect(res).toEqual({ transactionHandler, latestCount: currentCount });
     });
 
-    it("should save snapshot if snapshot is needed at anytime for devnet", async () => {
+    it("should save snapshot in time limit for devnet", async () => {
+      const savingPeriod = snapshotSavingPeriod[Network.DEVNET];
       const currentCount = 6;
       count = -1;
       veaInbox.count.mockResolvedValue(currentCount);
@@ -192,7 +194,7 @@ describe("snapshot", () => {
         snapshotNeeded: true,
         latestCount: currentCount,
       });
-      const now = 1801; // 600 seconds after the epoch started
+      const now = epochPeriod + epochPeriod - savingPeriod; // 60 seconds before the second epoch ends
       const transactionHandler = {
         saveSnapshot: jest.fn(),
       };

--- a/validator-cli/src/helpers/snapshot.ts
+++ b/validator-cli/src/helpers/snapshot.ts
@@ -1,8 +1,7 @@
-import { Network } from "../consts/bridgeRoutes";
+import { Network, snapshotSavingPeriod } from "../consts/bridgeRoutes";
 import { getLastMessageSaved } from "../utils/graphQueries";
 import { BotEvents } from "../utils/botEvents";
 import { defaultEmitter } from "../utils/emitter";
-import { snapshotSavingPeriod } from "../consts/bridgeRoutes";
 interface SnapshotCheckParams {
   chainId: number;
   veaInbox: any;

--- a/validator-cli/src/helpers/snapshot.ts
+++ b/validator-cli/src/helpers/snapshot.ts
@@ -2,7 +2,7 @@ import { Network } from "../consts/bridgeRoutes";
 import { getLastMessageSaved } from "../utils/graphQueries";
 import { BotEvents } from "../utils/botEvents";
 import { defaultEmitter } from "../utils/emitter";
-
+import { snapshotSavingPeriod } from "../consts/bridgeRoutes";
 interface SnapshotCheckParams {
   chainId: number;
   veaInbox: any;
@@ -33,14 +33,12 @@ export const saveSnapshot = async ({
   toSaveSnapshot = isSnapshotNeeded,
   now = Math.floor(Date.now() / 1000),
 }: SaveSnapshotParams): Promise<any> => {
-  if (network != Network.DEVNET) {
-    const timeElapsed = now % epochPeriod;
-    const timeLeftForEpoch = epochPeriod - timeElapsed;
-    // Saving snapshots in last 10 minutes of the epoch on testnet
-    if (timeLeftForEpoch > 600) {
-      emitter.emit(BotEvents.SNAPSHOT_WAITING, timeLeftForEpoch);
-      return { transactionHandler, latestCount: count };
-    }
+  const timeElapsed = now % epochPeriod;
+  const timeLeftForEpoch = epochPeriod - timeElapsed;
+
+  if (timeLeftForEpoch > snapshotSavingPeriod[network]) {
+    emitter.emit(BotEvents.SNAPSHOT_WAITING, timeLeftForEpoch);
+    return { transactionHandler, latestCount: count };
   }
   const { snapshotNeeded, latestCount } = await toSaveSnapshot({
     chainId,
@@ -71,7 +69,7 @@ export const isSnapshotNeeded = async ({
     const lastSavedMessageId = await fetchLastSavedMessage(veaInboxAddress, chainId);
     const messageIndex = extractMessageIndex(lastSavedMessageId);
     // adding 1 to the message index to get the last saved count
-    lastSavedCount = messageIndex + 1;
+    lastSavedCount = messageIndex;
   }
   if (currentCount > lastSavedCount) {
     return { snapshotNeeded: true, latestCount: currentCount };

--- a/validator-cli/src/utils/transactionHandlers/arbToEthHandler.ts
+++ b/validator-cli/src/utils/transactionHandlers/arbToEthHandler.ts
@@ -25,10 +25,9 @@ export class ArbToEthTransactionHandler extends BaseTransactionHandler<VeaInboxA
   public async makeClaim(stateRoot: string): Promise<void> {
     this.emitter.emit(BotEvents.CLAIMING, this.epoch);
     const now = Date.now();
-    const status = await this.checkTransactionStatus(this.transactions.claimTxn, ContractType.OUTBOX, now);
-    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) {
-      return;
-    }
+
+    const toSubmit = await this.toSubmitTransaction(this.transactions.claimTxn, ContractType.OUTBOX, now);
+    if (!toSubmit) return;
 
     const { routeConfig } = getBridgeConfig(this.chainId);
     const { deposit } = routeConfig[this.network];
@@ -51,10 +50,8 @@ export class ArbToEthTransactionHandler extends BaseTransactionHandler<VeaInboxA
     this.emitter.emit(BotEvents.CHALLENGING, this.epoch);
     if (!this.claim) throw new ClaimNotSetError();
     const now = Date.now();
-    const status = await this.checkTransactionStatus(this.transactions.challengeTxn, ContractType.OUTBOX, now);
-    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) {
-      return;
-    }
+    const toSubmit = await this.toSubmitTransaction(this.transactions.challengeTxn, ContractType.OUTBOX, now);
+    if (!toSubmit) return;
 
     const { routeConfig } = getBridgeConfig(this.chainId);
     const { deposit } = routeConfig[this.network];
@@ -92,10 +89,8 @@ export class ArbToEthTransactionHandler extends BaseTransactionHandler<VeaInboxA
     if (!this.claim) throw new ClaimNotSetError();
 
     const now = Date.now();
-    const status = await this.checkTransactionStatus(this.transactions.sendSnapshotTxn, ContractType.INBOX, now);
-    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) {
-      return;
-    }
+    const toSubmit = await this.toSubmitTransaction(this.transactions.sendSnapshotTxn, ContractType.INBOX, now);
+    if (!toSubmit) return;
 
     const tx = await this.veaInbox.sendSnapshot(this.epoch, this.claim);
     this.emitter.emit(BotEvents.TXN_MADE, tx.hash, this.epoch, "Send Snapshot");
@@ -108,10 +103,8 @@ export class ArbToEthTransactionHandler extends BaseTransactionHandler<VeaInboxA
   public async resolveChallengedClaim(sendSnapshotHash: string, execFn = messageExecutor): Promise<void> {
     this.emitter.emit(BotEvents.EXECUTING_SNAPSHOT, this.epoch);
     const now = Date.now();
-    const status = await this.checkTransactionStatus(this.transactions.executeSnapshotTxn, ContractType.OUTBOX, now);
-    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) {
-      return;
-    }
+    const toSubmit = await this.toSubmitTransaction(this.transactions.executeSnapshotTxn, ContractType.OUTBOX, now);
+    if (!toSubmit) return;
 
     const result = await execFn(sendSnapshotHash, this.veaInboxProvider, this.veaOutboxProvider);
     this.emitter.emit(BotEvents.TXN_MADE, result.hash, this.epoch, "Execute Snapshot");
@@ -142,10 +135,8 @@ export class ArbToEthDevnetTransactionHandler extends ArbToEthTransactionHandler
   public async devnetAdvanceState(stateRoot: string): Promise<void> {
     this.emitter.emit(BotEvents.ADV_DEVNET, this.epoch);
     const now = Date.now();
-    const status = await this.checkTransactionStatus(this.transactions.devnetAdvanceStateTxn, ContractType.OUTBOX, now);
-    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) {
-      return;
-    }
+    const toSubmit = await this.toSubmitTransaction(this.transactions.devnetAdvanceStateTxn, ContractType.OUTBOX, now);
+    if (!toSubmit) return;
     const { routeConfig } = getBridgeConfig(this.chainId);
     const { deposit } = routeConfig[Network.DEVNET];
     const tx = await this.veaOutboxDevnet.devnetAdvanceState(this.epoch, stateRoot, {

--- a/validator-cli/src/utils/transactionHandlers/arbToEthHandler.ts
+++ b/validator-cli/src/utils/transactionHandlers/arbToEthHandler.ts
@@ -26,7 +26,7 @@ export class ArbToEthTransactionHandler extends BaseTransactionHandler<VeaInboxA
     this.emitter.emit(BotEvents.CLAIMING, this.epoch);
     const now = Date.now();
     const status = await this.checkTransactionStatus(this.transactions.claimTxn, ContractType.OUTBOX, now);
-    if (status !== TransactionStatus.NOT_MADE && status !== TransactionStatus.EXPIRED) {
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) {
       return;
     }
 
@@ -52,7 +52,7 @@ export class ArbToEthTransactionHandler extends BaseTransactionHandler<VeaInboxA
     if (!this.claim) throw new ClaimNotSetError();
     const now = Date.now();
     const status = await this.checkTransactionStatus(this.transactions.challengeTxn, ContractType.OUTBOX, now);
-    if (status !== TransactionStatus.NOT_MADE && status !== TransactionStatus.EXPIRED) {
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) {
       return;
     }
 
@@ -93,7 +93,7 @@ export class ArbToEthTransactionHandler extends BaseTransactionHandler<VeaInboxA
 
     const now = Date.now();
     const status = await this.checkTransactionStatus(this.transactions.sendSnapshotTxn, ContractType.INBOX, now);
-    if (status !== TransactionStatus.NOT_MADE && status !== TransactionStatus.EXPIRED) {
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) {
       return;
     }
 
@@ -109,7 +109,7 @@ export class ArbToEthTransactionHandler extends BaseTransactionHandler<VeaInboxA
     this.emitter.emit(BotEvents.EXECUTING_SNAPSHOT, this.epoch);
     const now = Date.now();
     const status = await this.checkTransactionStatus(this.transactions.executeSnapshotTxn, ContractType.OUTBOX, now);
-    if (status !== TransactionStatus.NOT_MADE && status !== TransactionStatus.EXPIRED) {
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) {
       return;
     }
 
@@ -143,7 +143,7 @@ export class ArbToEthDevnetTransactionHandler extends ArbToEthTransactionHandler
     this.emitter.emit(BotEvents.ADV_DEVNET, this.epoch);
     const now = Date.now();
     const status = await this.checkTransactionStatus(this.transactions.devnetAdvanceStateTxn, ContractType.OUTBOX, now);
-    if (status !== TransactionStatus.NOT_MADE && status !== TransactionStatus.EXPIRED) {
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) {
       return;
     }
     const { routeConfig } = getBridgeConfig(this.chainId);

--- a/validator-cli/src/utils/transactionHandlers/arbToGnosisHandler.ts
+++ b/validator-cli/src/utils/transactionHandlers/arbToGnosisHandler.ts
@@ -42,7 +42,7 @@ export class ArbToGnosisTransactionHandler extends BaseTransactionHandler<VeaInb
     this.emitter.emit(BotEvents.CLAIMING, this.epoch);
     const now = Date.now();
     const status = await this.checkTransactionStatus(this.transactions.claimTxn, ContractType.OUTBOX, now);
-    if (status !== TransactionStatus.NOT_MADE && status !== TransactionStatus.EXPIRED) return;
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
 
     // Approves WETH for the claim if not already approved
     await this.approveWeth();
@@ -58,7 +58,7 @@ export class ArbToGnosisTransactionHandler extends BaseTransactionHandler<VeaInb
     if (!this.claim) throw new ClaimNotSetError();
     const now = Date.now();
     const status = await this.checkTransactionStatus(this.transactions.challengeTxn, ContractType.OUTBOX, now);
-    if (status !== TransactionStatus.NOT_MADE && status !== TransactionStatus.EXPIRED) return;
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
 
     const gasEstimate = await this.veaOutbox[
       "challenge(uint256,(bytes32,address,uint32,uint32,uint32,uint8,address))"
@@ -86,7 +86,7 @@ export class ArbToGnosisTransactionHandler extends BaseTransactionHandler<VeaInb
     if (!this.claim) throw new ClaimNotSetError();
     const now = Date.now();
     const status = await this.checkTransactionStatus(this.transactions.sendSnapshotTxn, ContractType.INBOX, now);
-    if (status !== TransactionStatus.NOT_MADE && status !== TransactionStatus.EXPIRED) return;
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
 
     const ambGasLimit = BigInt(3000000);
     const tx = await this.veaInbox.sendSnapshot(this.epoch, ambGasLimit, this.claim);
@@ -99,7 +99,7 @@ export class ArbToGnosisTransactionHandler extends BaseTransactionHandler<VeaInb
     if (!this.claim) throw new ClaimNotSetError();
     const now = Date.now();
     const status = await this.checkTransactionStatus(this.transactions.executeSnapshotTxn, ContractType.ROUTER, now);
-    if (status !== TransactionStatus.NOT_MADE && status !== TransactionStatus.EXPIRED) return;
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
     const msgExecuteTrnx = await messageExecutor(sendSnapshotTxn, this.veaInboxProvider, this.veaRouterProvider);
     this.emitter.emit(BotEvents.TXN_MADE, msgExecuteTrnx.hash, this.epoch, "Execute Snapshot");
     this.transactions.executeSnapshotTxn = {
@@ -135,7 +135,7 @@ export class ArbToGnosisDevnetTransactionHandler extends ArbToGnosisTransactionH
     this.emitter.emit(BotEvents.ADV_DEVNET, this.epoch);
     const now = Date.now();
     const status = await this.checkTransactionStatus(this.transactions.devnetAdvanceStateTxn, ContractType.OUTBOX, now);
-    if (status !== TransactionStatus.NOT_MADE && status !== TransactionStatus.EXPIRED) return;
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
     await this.approveWeth();
     const { routeConfig } = getBridgeConfig(this.chainId);
     const { deposit } = routeConfig[Network.DEVNET];

--- a/validator-cli/src/utils/transactionHandlers/arbToGnosisHandler.ts
+++ b/validator-cli/src/utils/transactionHandlers/arbToGnosisHandler.ts
@@ -41,8 +41,8 @@ export class ArbToGnosisTransactionHandler extends BaseTransactionHandler<VeaInb
   public async makeClaim(stateRoot: string): Promise<void> {
     this.emitter.emit(BotEvents.CLAIMING, this.epoch);
     const now = Date.now();
-    const status = await this.checkTransactionStatus(this.transactions.claimTxn, ContractType.OUTBOX, now);
-    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
+    const toSubmit = await this.toSubmitTransaction(this.transactions.claimTxn, ContractType.OUTBOX, now);
+    if (!toSubmit) return;
 
     // Approves WETH for the claim if not already approved
     await this.approveWeth();
@@ -57,8 +57,8 @@ export class ArbToGnosisTransactionHandler extends BaseTransactionHandler<VeaInb
     this.emitter.emit(BotEvents.CHALLENGING, this.epoch);
     if (!this.claim) throw new ClaimNotSetError();
     const now = Date.now();
-    const status = await this.checkTransactionStatus(this.transactions.challengeTxn, ContractType.OUTBOX, now);
-    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
+    const toSubmit = await this.toSubmitTransaction(this.transactions.challengeTxn, ContractType.OUTBOX, now);
+    if (!toSubmit) return;
 
     const gasEstimate = await this.veaOutbox[
       "challenge(uint256,(bytes32,address,uint32,uint32,uint32,uint8,address))"
@@ -85,8 +85,8 @@ export class ArbToGnosisTransactionHandler extends BaseTransactionHandler<VeaInb
     this.emitter.emit(BotEvents.SENDING_SNAPSHOT, this.epoch);
     if (!this.claim) throw new ClaimNotSetError();
     const now = Date.now();
-    const status = await this.checkTransactionStatus(this.transactions.sendSnapshotTxn, ContractType.INBOX, now);
-    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
+    const toSubmit = await this.toSubmitTransaction(this.transactions.sendSnapshotTxn, ContractType.INBOX, now);
+    if (!toSubmit) return;
 
     const ambGasLimit = BigInt(3000000);
     const tx = await this.veaInbox.sendSnapshot(this.epoch, ambGasLimit, this.claim);
@@ -98,8 +98,8 @@ export class ArbToGnosisTransactionHandler extends BaseTransactionHandler<VeaInb
     this.emitter.emit(BotEvents.EXECUTING_SNAPSHOT, this.epoch);
     if (!this.claim) throw new ClaimNotSetError();
     const now = Date.now();
-    const status = await this.checkTransactionStatus(this.transactions.executeSnapshotTxn, ContractType.ROUTER, now);
-    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
+    const toSubmit = await this.toSubmitTransaction(this.transactions.executeSnapshotTxn, ContractType.ROUTER, now);
+    if (!toSubmit) return;
     const msgExecuteTrnx = await messageExecutor(sendSnapshotTxn, this.veaInboxProvider, this.veaRouterProvider);
     this.emitter.emit(BotEvents.TXN_MADE, msgExecuteTrnx.hash, this.epoch, "Execute Snapshot");
     this.transactions.executeSnapshotTxn = {
@@ -134,8 +134,8 @@ export class ArbToGnosisDevnetTransactionHandler extends ArbToGnosisTransactionH
   public async devnetAdvanceState(stateRoot: string): Promise<void> {
     this.emitter.emit(BotEvents.ADV_DEVNET, this.epoch);
     const now = Date.now();
-    const status = await this.checkTransactionStatus(this.transactions.devnetAdvanceStateTxn, ContractType.OUTBOX, now);
-    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
+    const toSubmit = await this.toSubmitTransaction(this.transactions.devnetAdvanceStateTxn, ContractType.OUTBOX, now);
+    if (!toSubmit) return;
     await this.approveWeth();
     const { routeConfig } = getBridgeConfig(this.chainId);
     const { deposit } = routeConfig[Network.DEVNET];

--- a/validator-cli/src/utils/transactionHandlers/baseTransactionHandler.ts
+++ b/validator-cli/src/utils/transactionHandlers/baseTransactionHandler.ts
@@ -195,7 +195,7 @@ export abstract class BaseTransactionHandler<Inbox, Outbox> implements ITransact
 
     const now = Date.now();
     const status = await this.checkTransactionStatus(this.transactions.startVerificationTxn, ContractType.OUTBOX, now);
-    if (status !== TransactionStatus.NOT_MADE && status !== TransactionStatus.EXPIRED) return;
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
 
     const cfg = getBridgeConfig(this.chainId);
     const timeOver =
@@ -223,7 +223,7 @@ export abstract class BaseTransactionHandler<Inbox, Outbox> implements ITransact
 
     const now = Date.now();
     const status = await this.checkTransactionStatus(this.transactions.verifySnapshotTxn, ContractType.OUTBOX, now);
-    if (status !== TransactionStatus.NOT_MADE && status !== TransactionStatus.EXPIRED) return;
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
 
     const cfg = getBridgeConfig(this.chainId);
     const timeLeft = currentTimestamp - Number(this.claim.timestampVerification) - cfg.minChallengePeriod;
@@ -251,7 +251,7 @@ export abstract class BaseTransactionHandler<Inbox, Outbox> implements ITransact
       ContractType.OUTBOX,
       now
     );
-    if (status !== TransactionStatus.NOT_MADE && status !== TransactionStatus.EXPIRED) return;
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
 
     const tx = await (this.veaOutbox as any).withdrawClaimDeposit(this.epoch, this.claim);
     this.emitter.emit(BotEvents.TXN_MADE, tx.hash, this.epoch, "Withdraw Claim Deposit");
@@ -271,7 +271,7 @@ export abstract class BaseTransactionHandler<Inbox, Outbox> implements ITransact
       ContractType.OUTBOX,
       now
     );
-    if (status !== TransactionStatus.NOT_MADE && status !== TransactionStatus.EXPIRED) return;
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
 
     const tx = await (this.veaOutbox as any).withdrawChallengeDeposit(this.epoch, this.claim);
     this.emitter.emit(BotEvents.TXN_MADE, tx.hash, this.epoch, "Withdraw Challenge Deposit");
@@ -286,7 +286,7 @@ export abstract class BaseTransactionHandler<Inbox, Outbox> implements ITransact
 
     const now = Date.now();
     const status = await this.checkTransactionStatus(this.transactions.saveSnapshotTxn, ContractType.INBOX, now);
-    if (status !== TransactionStatus.NOT_MADE && status !== TransactionStatus.EXPIRED) return;
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
 
     const tx = await (this.veaInbox as any).saveSnapshot();
     this.emitter.emit(BotEvents.TXN_MADE, tx.hash, this.epoch, "Save Snapshot");

--- a/validator-cli/src/utils/transactionHandlers/baseTransactionHandler.ts
+++ b/validator-cli/src/utils/transactionHandlers/baseTransactionHandler.ts
@@ -189,13 +189,23 @@ export abstract class BaseTransactionHandler<Inbox, Outbox> implements ITransact
     return TransactionStatus.NOT_FINAL;
   }
 
+  public async toSubmitTransaction(
+    trnx: Transaction | null,
+    contract: ContractType,
+    currentTime: number
+  ): Promise<boolean> {
+    const status = await this.checkTransactionStatus(trnx, contract, currentTime);
+    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return false;
+    return true;
+  }
+
   public async startVerification(currentTimestamp: number) {
     this.emitter.emit(BotEvents.STARTING_VERIFICATION, this.epoch);
     if (!this.claim) throw new ClaimNotSetError();
 
     const now = Date.now();
-    const status = await this.checkTransactionStatus(this.transactions.startVerificationTxn, ContractType.OUTBOX, now);
-    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
+    const toSubmit = await this.toSubmitTransaction(this.transactions.startVerificationTxn, ContractType.OUTBOX, now);
+    if (!toSubmit) return;
 
     const cfg = getBridgeConfig(this.chainId);
     const timeOver =
@@ -222,8 +232,8 @@ export abstract class BaseTransactionHandler<Inbox, Outbox> implements ITransact
     if (!this.claim) throw new ClaimNotSetError();
 
     const now = Date.now();
-    const status = await this.checkTransactionStatus(this.transactions.verifySnapshotTxn, ContractType.OUTBOX, now);
-    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
+    const toSubmit = await this.toSubmitTransaction(this.transactions.verifySnapshotTxn, ContractType.OUTBOX, now);
+    if (!toSubmit) return;
 
     const cfg = getBridgeConfig(this.chainId);
     const timeLeft = currentTimestamp - Number(this.claim.timestampVerification) - cfg.minChallengePeriod;
@@ -246,12 +256,12 @@ export abstract class BaseTransactionHandler<Inbox, Outbox> implements ITransact
     if (!this.claim) throw new ClaimNotSetError();
 
     const now = Date.now();
-    const status = await this.checkTransactionStatus(
+    const toSubmit = await this.toSubmitTransaction(
       this.transactions.withdrawClaimDepositTxn,
       ContractType.OUTBOX,
       now
     );
-    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
+    if (!toSubmit) return;
 
     const tx = await (this.veaOutbox as any).withdrawClaimDeposit(this.epoch, this.claim);
     this.emitter.emit(BotEvents.TXN_MADE, tx.hash, this.epoch, "Withdraw Claim Deposit");
@@ -266,12 +276,12 @@ export abstract class BaseTransactionHandler<Inbox, Outbox> implements ITransact
     if (!this.claim) throw new ClaimNotSetError();
 
     const now = Date.now();
-    const status = await this.checkTransactionStatus(
+    const toSubmit = await this.toSubmitTransaction(
       this.transactions.withdrawChallengeDepositTxn,
       ContractType.OUTBOX,
       now
     );
-    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
+    if (!toSubmit) return;
 
     const tx = await (this.veaOutbox as any).withdrawChallengeDeposit(this.epoch, this.claim);
     this.emitter.emit(BotEvents.TXN_MADE, tx.hash, this.epoch, "Withdraw Challenge Deposit");
@@ -285,8 +295,8 @@ export abstract class BaseTransactionHandler<Inbox, Outbox> implements ITransact
     this.emitter.emit(BotEvents.SAVING_SNAPSHOT, this.epoch);
 
     const now = Date.now();
-    const status = await this.checkTransactionStatus(this.transactions.saveSnapshotTxn, ContractType.INBOX, now);
-    if (status === TransactionStatus.PENDING || status === TransactionStatus.NOT_FINAL) return;
+    const toSubmit = await this.toSubmitTransaction(this.transactions.saveSnapshotTxn, ContractType.INBOX, now);
+    if (!toSubmit) return;
 
     const tx = await (this.veaInbox as any).saveSnapshot();
     this.emitter.emit(BotEvents.TXN_MADE, tx.hash, this.epoch, "Save Snapshot");


### PR DESCRIPTION
- Introduced  snapshot saving period (1 m 30s) for devnet similar to testnet.
- Epoch period for devnet updated to 5 mins.
- Transaction status check fixed for all transactions, earlier a "FINAL" transaction had to be waited till expiration limit which was not the intended behaviour.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the snapshot saving functionality in the `validator-cli` by updating the logic for determining when snapshots should be saved, adjusting epoch periods, and refactoring transaction handling to streamline the process.

### Detailed summary
- Renamed test case in `snapshot.test.ts` for clarity.
- Added `snapshotSavingPeriod` for `Network` configurations.
- Updated logic in `saveSnapshot` to use `snapshotSavingPeriod`.
- Changed epoch period from 1800 to 300 seconds for `DEVNET` and `TESTNET`.
- Refactored transaction checks in various handlers to utilize `toSubmitTransaction` method for consistency.
- Exported `snapshotSavingPeriod` from `bridgeRoutes.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Per-network snapshot saving window with tailored thresholds for DEVNET and TESTNET.
  - Devnet-specific transaction paths added for state advancement.

- Improvements
  - Shorter DEVNET epoch for faster cycles.
  - Snapshotting now applies across networks with dynamic timing.
  - Unified transaction gating: actions allowed in more states (blocked only when pending/not-final), reducing delays.
  - Improved gas-price handling for one bridge path to better cap fees.

- Tests
  - Tests updated to use dynamic saving periods instead of hard-coded timestamps.

- Chores
  - Public API exports and signatures updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->