### PR TITLE
Fix/outbox resolution

### DIFF
--- a/contracts/src/arbitrumToEth/VeaOutboxArbToEth.sol
+++ b/contracts/src/arbitrumToEth/VeaOutboxArbToEth.sol
@@ -85,6 +85,10 @@ contract VeaOutboxArbToEth is IVeaOutboxOnL1 {
     /// @param _epoch The epoch that was verified.
     event Verified(uint256 _epoch);
 
+    /// @dev This event indicates that a resolution has failed.
+    /// @param _epoch The epoch for which resolution failed.
+    event FailedResolution(uint256 _epoch);
+
     /// @dev This event indicates the sequencer limit updated.
     /// @param _newSequencerDelayLimit The new sequencer delay limit.
     event SequencerDelayLimitUpdated(uint256 _newSequencerDelayLimit);
@@ -347,9 +351,10 @@ contract VeaOutboxArbToEth is IVeaOutboxOnL1 {
                 _claim.honest = Party.Challenger;
             }
             claimHashes[_epoch] = hashClaim(_claim);
+            emit Verified(_epoch);
+        } else {
+            emit FailedResolution(_epoch);
         }
-
-        emit Verified(_epoch);
     }
 
     /// @dev Verifies and relays the message. UNTRUSTED.

--- a/contracts/src/arbitrumToEth/VeaOutboxArbToEth.sol
+++ b/contracts/src/arbitrumToEth/VeaOutboxArbToEth.sol
@@ -278,6 +278,7 @@ contract VeaOutboxArbToEth is IVeaOutboxOnL1 {
     /// @param _claim The claim associated with the epoch.
     function startVerification(uint256 _epoch, Claim memory _claim) external virtual {
         require(claimHashes[_epoch] == hashClaim(_claim), "Invalid claim.");
+        require(_claim.challenger == address(0), "Claim is challenged.");
 
         // sequencerDelayLimit + epochPeriod is the worst case time to sync the L2 state compared to L1 clock.
         // using checked arithmetic incase arbitrum governance sets sequencerDelayLimit to a large value

--- a/contracts/src/arbitrumToGnosis/VeaOutboxArbToGnosis.sol
+++ b/contracts/src/arbitrumToGnosis/VeaOutboxArbToGnosis.sol
@@ -81,6 +81,10 @@ contract VeaOutboxArbToGnosis is IVeaOutboxOnL1, ISequencerDelayUpdatable {
     /// @param _epoch The epoch that was verified.
     event Verified(uint256 _epoch);
 
+    /// @dev This event indicates that a resolution has failed.
+    /// @param _epoch The epoch for which resolution failed.
+    event FailedResolution(uint256 _epoch);
+
     /// @dev This event indicates the sequencer limit updated.
     /// @param _newSequencerDelayLimit The new sequencer delay limit.
     event SequencerDelayLimitUpdateReceived(uint256 _newSequencerDelayLimit);
@@ -291,9 +295,10 @@ contract VeaOutboxArbToGnosis is IVeaOutboxOnL1, ISequencerDelayUpdatable {
                 _claim.honest = Party.Challenger;
             }
             claimHashes[_epoch] = hashClaim(_claim);
+            emit Verified(_epoch);
+        } else {
+            emit FailedResolution(_epoch);
         }
-
-        emit Verified(_epoch);
     }
 
     /// @dev Verifies and relays the message. UNTRUSTED.

--- a/contracts/src/arbitrumToGnosis/VeaOutboxArbToGnosis.sol
+++ b/contracts/src/arbitrumToGnosis/VeaOutboxArbToGnosis.sol
@@ -224,6 +224,7 @@ contract VeaOutboxArbToGnosis is IVeaOutboxOnL1, ISequencerDelayUpdatable {
     /// @param _claim The claim associated with the epoch.
     function startVerification(uint256 _epoch, Claim memory _claim) external virtual {
         require(claimHashes[_epoch] == hashClaim(_claim), "Invalid claim.");
+        require(_claim.challenger == address(0), "Claim is challenged.");
 
         // sequencerDelayLimit + epochPeriod is the worst case time to sync the L2 state compared to L1 clock.
         // using checked arithmetic incase arbitrum governance sets sequencerDelayLimit to a large value

--- a/contracts/src/gnosisToArbitrum/VeaOutboxGnosisToArb.sol
+++ b/contracts/src/gnosisToArbitrum/VeaOutboxGnosisToArb.sol
@@ -79,6 +79,10 @@ contract VeaOutboxGnosisToArb is IVeaOutboxOnL2 {
     /// @param _epoch The epoch that was verified.
     event Verified(uint256 indexed _epoch);
 
+    /// @dev This event indicates that a resolution has failed.
+    /// @param _epoch The epoch for which resolution failed.
+    event FailedResolution(uint256 _epoch);
+
     /// @dev This event indicates the sequencer delay limit updated.
     /// @param _newSequencerDelayLimit The new max sequencer past timestamping power.
     event SequencerDelayLimitUpdateReceived(uint256 _newSequencerDelayLimit);
@@ -277,9 +281,10 @@ contract VeaOutboxGnosisToArb is IVeaOutboxOnL2 {
             } else if (challengers[_epoch] != address(0)) {
                 claims[_epoch].honest = Party.Challenger;
             }
+            emit Verified(_epoch);
+        } else {
+            emit FailedResolution(_epoch);
         }
-
-        emit Verified(_epoch);
     }
 
     /// @dev Verifies and relays the message. UNTRUSTED.


### PR DESCRIPTION
- Added `FailedResolution` event, emitted when claim sent from Inbox does not match with claim on Outbox during a dispute resolution.
- Fixed emission of `Verified` event to emit only when the dispute is resolved in `resolveDisputeForClaim()`.
- Added a require in `startVerification()` to ensure that the claim can not be updated after it's been challenged. 
