### PR TITLE
Feat/validator rpc fallback

### DIFF
--- a/validator-cli/.env.dist
+++ b/validator-cli/.env.dist
@@ -5,6 +5,8 @@ NETWORKS=devnet,testnet
 
 
 # RPCs
+# Each RPC accepts a comma-separated list of endpoints. The first is primary; the rest are
+# used as automatic fallbacks (in order) whenever a request to the active endpoint fails.
 RPC_ARB=https://sepolia-rollup.arbitrum.io/rpc
 RPC_ETH=
 RPC_GNOSIS=https://rpc.chiadochain.net

--- a/validator-cli/Dockerfile
+++ b/validator-cli/Dockerfile
@@ -3,7 +3,7 @@
 #
 
 # Node version for Vea
-FROM node:24.4-alpine AS validator-build
+FROM node:24.14-alpine3.23 AS validator-build
 
 # Yarn version for Vea
 ARG YARN_VERSION=4.6.0
@@ -53,7 +53,7 @@ RUN yarn workspaces focus @kleros/vea-validator-cli
 # This is the final layer that will be deployed and run
 
 # Node version for Vea
-FROM node:24.4-alpine AS validator
+FROM node:24.14-alpine3.23 AS validator
 
 # Yarn version for Vea
 ARG YARN_VERSION=4.6.0

--- a/validator-cli/README.md
+++ b/validator-cli/README.md
@@ -28,3 +28,23 @@ Enables snapshot saving on the inbox when the bot observes a valid state.
 - challenger: Only challenge invalid claims
 - bridger: Only submit snapshots
 - both: Default mode, acts as both challenger and bridger
+
+# testing
+
+Tests are written with [Jest](https://jestjs.io/) (via `ts-jest`).
+
+Run the full suite with coverage:
+
+`yarn test`
+
+Run a single test file:
+
+`yarn jest src/helpers/validator.test.ts`
+
+Run tests matching a name pattern:
+
+`yarn jest -t "snapshot"`
+
+Run in watch mode while developing:
+
+`yarn jest --watch`

--- a/validator-cli/src/consts/bridgeRoutes.ts
+++ b/validator-cli/src/consts/bridgeRoutes.ts
@@ -15,12 +15,23 @@ export interface Bridge {
   chain: string;
   minChallengePeriod: number;
   sequencerDelayLimit: number;
-  inboxRPC: string;
-  outboxRPC: string;
-  routerRPC?: string;
+  // RPC endpoints are stored as ordered lists; the first is primary and the rest are fallbacks.
+  inboxRPC: string[];
+  outboxRPC: string[];
+  routerRPC?: string[];
   routeConfig: { [key in Network]: RouteConfigs };
   depositToken?: string;
 }
+
+/**
+ * Parse a comma-separated list of RPC URLs from an environment variable into an ordered array.
+ * Returns an empty array when the variable is unset so optional RPCs (e.g. router) stay optional.
+ */
+const splitRpcUrls = (value?: string): string[] =>
+  (value ?? "")
+    .split(",")
+    .map((url) => url.trim())
+    .filter((url) => url.length > 0);
 
 type RouteConfigs = {
   veaInbox: any;
@@ -71,17 +82,17 @@ const bridges: { [chainId: number]: Bridge } = {
     chain: "sepolia",
     minChallengePeriod: 10800,
     sequencerDelayLimit: 86400,
-    inboxRPC: process.env.RPC_ARB,
-    outboxRPC: process.env.RPC_ETH,
+    inboxRPC: splitRpcUrls(process.env.RPC_ARB),
+    outboxRPC: splitRpcUrls(process.env.RPC_ETH),
     routeConfig: arbToEthConfigs,
   },
   10200: {
     chain: "chiado",
     minChallengePeriod: 10800,
     sequencerDelayLimit: 86400,
-    inboxRPC: process.env.RPC_ARB,
-    outboxRPC: process.env.RPC_GNOSIS,
-    routerRPC: process.env.RPC_ETH,
+    inboxRPC: splitRpcUrls(process.env.RPC_ARB),
+    outboxRPC: splitRpcUrls(process.env.RPC_GNOSIS),
+    routerRPC: splitRpcUrls(process.env.RPC_ETH),
     routeConfig: arbToGnosisConfigs,
     depositToken: process.env.GNOSIS_WETH,
   },

--- a/validator-cli/src/utils/botEvents.ts
+++ b/validator-cli/src/utils/botEvents.ts
@@ -50,4 +50,8 @@ export enum BotEvents {
   CLAIM_MISMATCH = "claim_mismatch",
   FINALITY_ISSUE = "finality_issue",
   FINALITY_ERROR = "finality_error",
+
+  // RPC fallback state
+  RPC_FAILURE = "rpc_failure",
+  RPC_RECOVERED = "rpc_recovered",
 }

--- a/validator-cli/src/utils/ethers.ts
+++ b/validator-cli/src/utils/ethers.ts
@@ -13,33 +13,39 @@ import {
 import { NotDefinedError, InvalidNetworkError } from "./errors";
 import { Network } from "../consts/bridgeRoutes";
 
-function getWallet(privateKey: string, rpcUrl: string) {
-  return new Wallet(privateKey, new JsonRpcProvider(rpcUrl));
+function getWallet(privateKey: string, rpc: JsonRpcProvider) {
+  return new Wallet(privateKey, rpc);
 }
 
 function getWalletRPC(privateKey: string, rpc: JsonRpcProvider) {
   return new Wallet(privateKey, rpc);
 }
 
-function getVeaInbox(veaInboxAddress: string, privateKey: string, rpcUrl: string, chainId: number, network) {
+function getVeaInbox(veaInboxAddress: string, privateKey: string, rpc: JsonRpcProvider, chainId: number, network) {
   switch (chainId) {
     case 11155111:
-      return VeaInboxArbToEth__factory.connect(veaInboxAddress, getWallet(privateKey, rpcUrl));
+      return VeaInboxArbToEth__factory.connect(veaInboxAddress, getWallet(privateKey, rpc));
     case 10200:
-      return VeaInboxArbToGnosis__factory.connect(veaInboxAddress, getWallet(privateKey, rpcUrl));
+      return VeaInboxArbToGnosis__factory.connect(veaInboxAddress, getWallet(privateKey, rpc));
     default:
       throw new NotDefinedError("VeaInbox");
   }
 }
 
-function getVeaOutbox(veaOutboxAddress: string, privateKey: string, rpcUrl: string, chainId: number, network: Network) {
+function getVeaOutbox(
+  veaOutboxAddress: string,
+  privateKey: string,
+  rpc: JsonRpcProvider,
+  chainId: number,
+  network: Network
+) {
   switch (chainId) {
     case 11155111:
       switch (network) {
         case Network.DEVNET:
-          return VeaOutboxArbToEthDevnet__factory.connect(veaOutboxAddress, getWallet(privateKey, rpcUrl));
+          return VeaOutboxArbToEthDevnet__factory.connect(veaOutboxAddress, getWallet(privateKey, rpc));
         case Network.TESTNET:
-          return VeaOutboxArbToEth__factory.connect(veaOutboxAddress, getWallet(privateKey, rpcUrl));
+          return VeaOutboxArbToEth__factory.connect(veaOutboxAddress, getWallet(privateKey, rpc));
         default:
           throw new InvalidNetworkError(`${network}(veaOutbox)`);
       }
@@ -47,9 +53,9 @@ function getVeaOutbox(veaOutboxAddress: string, privateKey: string, rpcUrl: stri
     case 10200:
       switch (network) {
         case Network.DEVNET:
-          return VeaOutboxArbToGnosisDevnet__factory.connect(veaOutboxAddress, getWallet(privateKey, rpcUrl));
+          return VeaOutboxArbToGnosisDevnet__factory.connect(veaOutboxAddress, getWallet(privateKey, rpc));
         case Network.TESTNET:
-          return VeaOutboxArbToGnosis__factory.connect(veaOutboxAddress, getWallet(privateKey, rpcUrl));
+          return VeaOutboxArbToGnosis__factory.connect(veaOutboxAddress, getWallet(privateKey, rpc));
         default:
           throw new InvalidNetworkError(`${network}(veaOutbox)`);
       }
@@ -58,23 +64,23 @@ function getVeaOutbox(veaOutboxAddress: string, privateKey: string, rpcUrl: stri
   }
 }
 
-function getVeaRouter(veaRouterAddress: string, privateKey: string, rpcUrl: string, chainId: number) {
+function getVeaRouter(veaRouterAddress: string, privateKey: string, rpc: JsonRpcProvider, chainId: number) {
   switch (chainId) {
     case 10200:
-      return RouterArbToGnosis__factory.connect(veaRouterAddress, getWallet(privateKey, rpcUrl));
+      return RouterArbToGnosis__factory.connect(veaRouterAddress, getWallet(privateKey, rpc));
   }
 }
 
-function getWETH(WETH: string, privateKey: string, rpcUrl: string) {
-  return IWETH__factory.connect(WETH, getWallet(privateKey, rpcUrl));
+function getWETH(WETH: string, privateKey: string, rpc: JsonRpcProvider) {
+  return IWETH__factory.connect(WETH, getWallet(privateKey, rpc));
 }
 
-function getVeaOutboxArbToEthDevnet(veaOutboxAddress: string, privateKey: string, rpcUrl: string) {
-  return VeaOutboxArbToEthDevnet__factory.connect(veaOutboxAddress, getWallet(privateKey, rpcUrl));
+function getVeaOutboxArbToEthDevnet(veaOutboxAddress: string, privateKey: string, rpc: JsonRpcProvider) {
+  return VeaOutboxArbToEthDevnet__factory.connect(veaOutboxAddress, getWallet(privateKey, rpc));
 }
 
-function getAMB(ambAddress: string, privateKey: string, rpcUrl: string) {
-  return IAMB__factory.connect(ambAddress, getWallet(privateKey, rpcUrl));
+function getAMB(ambAddress: string, privateKey: string, rpc: JsonRpcProvider) {
+  return IAMB__factory.connect(ambAddress, getWallet(privateKey, rpc));
 }
 
 export {

--- a/validator-cli/src/utils/fallbackProvider.ts
+++ b/validator-cli/src/utils/fallbackProvider.ts
@@ -6,10 +6,6 @@ type RPCEndpoint = { url: string; label?: string };
 
 /**
  * ethers v6 JSON-RPC provider that transparently fails over to the next endpoint when a request fails.
- *
- * Used for the typechain contract connections (veaInbox/veaOutbox wallets) which require an ethers v6 provider.
- * When `chainId` is provided the network is treated as static (no detection RPC), matching the relayer behaviour.
- * When omitted the network is detected lazily through the fallback transport, so a bad first URL never blocks startup.
  */
 export class FallbackRpcProvider extends JsonRpcProvider {
   private endpoints: RPCEndpoint[];
@@ -28,8 +24,6 @@ export class FallbackRpcProvider extends JsonRpcProvider {
     this.staticChainId = chainId;
   }
 
-  // When the chainId is known, return it without any RPC call so a bad first URL never blocks startup.
-  // Otherwise detect through the (fallback-protected) transport.
   async _detectNetwork(): Promise<Network> {
     if (this.staticChainId !== undefined) return Network.from(this.staticChainId);
     return super._detectNetwork();
@@ -67,7 +61,6 @@ export class FallbackRpcProvider extends JsonRpcProvider {
 
   private getInner(i: number) {
     if (!this.inner[i]) {
-      // Pass the static network (when known) so inner providers never attempt their own network detection.
       this.inner[i] = new JsonRpcProvider(
         this.endpoints[i].url,
         this.staticChainId !== undefined ? Network.from(this.staticChainId) : undefined

--- a/validator-cli/src/utils/fallbackProvider.ts
+++ b/validator-cli/src/utils/fallbackProvider.ts
@@ -1,0 +1,78 @@
+import { EventEmitter } from "node:events";
+import { JsonRpcPayload, JsonRpcResult, JsonRpcProvider, Network } from "ethers";
+import { BotEvents } from "./botEvents";
+
+type RPCEndpoint = { url: string; label?: string };
+
+/**
+ * ethers v6 JSON-RPC provider that transparently fails over to the next endpoint when a request fails.
+ *
+ * Used for the typechain contract connections (veaInbox/veaOutbox wallets) which require an ethers v6 provider.
+ * When `chainId` is provided the network is treated as static (no detection RPC), matching the relayer behaviour.
+ * When omitted the network is detected lazily through the fallback transport, so a bad first URL never blocks startup.
+ */
+export class FallbackRpcProvider extends JsonRpcProvider {
+  private endpoints: RPCEndpoint[];
+  private activeIndex = 0;
+  private emitter: EventEmitter;
+  private staticChainId?: number;
+  private inner: JsonRpcProvider[] = [];
+
+  constructor(endpoints: string | (string | RPCEndpoint)[], emitter: EventEmitter, chainId?: number) {
+    const list = Array.isArray(endpoints) ? endpoints : [endpoints];
+    const normalized = list.map((e) => (typeof e === "string" ? { url: e } : e));
+    if (normalized.length === 0) throw new Error("FallbackRpcProvider requires at least one RPC endpoint");
+    super(normalized[0].url, chainId !== undefined ? Network.from(chainId) : undefined);
+    this.endpoints = normalized;
+    this.emitter = emitter;
+    this.staticChainId = chainId;
+  }
+
+  // When the chainId is known, return it without any RPC call so a bad first URL never blocks startup.
+  // Otherwise detect through the (fallback-protected) transport.
+  async _detectNetwork(): Promise<Network> {
+    if (this.staticChainId !== undefined) return Network.from(this.staticChainId);
+    return super._detectNetwork();
+  }
+
+  private label(i: number) {
+    return this.endpoints[i].label ?? this.endpoints[i].url;
+  }
+
+  // Overrides the low-level transport so ALL RPC calls (including internal ones like eth_chainId) go through fallback logic.
+  async _send(payload: JsonRpcPayload | Array<JsonRpcPayload>): Promise<Array<JsonRpcResult>> {
+    const method = Array.isArray(payload) ? "batch" : payload.method;
+    let lastErr: any;
+    for (let attempt = 0; attempt < this.endpoints.length; attempt++) {
+      const i = (this.activeIndex + attempt) % this.endpoints.length;
+      try {
+        const result = await this.getInner(i)._send(payload);
+        if (i !== this.activeIndex) {
+          this.emitter.emit(BotEvents.RPC_RECOVERED, { method, from: this.label(this.activeIndex), to: this.label(i) });
+          this.activeIndex = i;
+        }
+        return result;
+      } catch (err: any) {
+        lastErr = err;
+        this.emitter.emit(BotEvents.RPC_FAILURE, {
+          method,
+          from: this.label(this.activeIndex),
+          to: this.label(i),
+          err,
+        });
+      }
+    }
+    throw lastErr;
+  }
+
+  private getInner(i: number) {
+    if (!this.inner[i]) {
+      // Pass the static network (when known) so inner providers never attempt their own network detection.
+      this.inner[i] = new JsonRpcProvider(
+        this.endpoints[i].url,
+        this.staticChainId !== undefined ? Network.from(this.staticChainId) : undefined
+      );
+    }
+    return this.inner[i];
+  }
+}

--- a/validator-cli/src/utils/fallbackProviderV5.ts
+++ b/validator-cli/src/utils/fallbackProviderV5.ts
@@ -7,13 +7,6 @@ type RPCEndpoint = { url: string; label?: string };
 /**
  * ethers v5 (`@ethersproject/providers`) JSON-RPC provider that transparently fails over to the next
  * endpoint when a request fails.
- *
- * Used for the standalone providers (veaInbox/veaOutbox/veaRouter) that feed the Arbitrum SDK and the
- * event/finality queries, which require an ethers v5 `JsonRpcProvider` instance.
- *
- * The transport is overridden at the low level (`send`), so every call - including the `eth_chainId`
- * issued during lazy network detection and every call the Arbitrum SDK proxies through
- * `provider.send` - benefits from the fallback rotation.
  */
 export class FallbackProviderV5 extends JsonRpcProvider {
   private endpoints: RPCEndpoint[];
@@ -25,7 +18,6 @@ export class FallbackProviderV5 extends JsonRpcProvider {
     const list = Array.isArray(endpoints) ? endpoints : [endpoints];
     const normalized = list.map((e) => (typeof e === "string" ? { url: e } : e));
     if (normalized.length === 0) throw new Error("FallbackProviderV5 requires at least one RPC endpoint");
-    // No static network: the chainId is detected lazily through the (fallback-protected) transport.
     super(normalized[0].url);
     this.endpoints = normalized;
     this.emitter = emitter;

--- a/validator-cli/src/utils/fallbackProviderV5.ts
+++ b/validator-cli/src/utils/fallbackProviderV5.ts
@@ -1,0 +1,69 @@
+import { EventEmitter } from "node:events";
+import { JsonRpcProvider } from "@ethersproject/providers";
+import { BotEvents } from "./botEvents";
+
+type RPCEndpoint = { url: string; label?: string };
+
+/**
+ * ethers v5 (`@ethersproject/providers`) JSON-RPC provider that transparently fails over to the next
+ * endpoint when a request fails.
+ *
+ * Used for the standalone providers (veaInbox/veaOutbox/veaRouter) that feed the Arbitrum SDK and the
+ * event/finality queries, which require an ethers v5 `JsonRpcProvider` instance.
+ *
+ * The transport is overridden at the low level (`send`), so every call - including the `eth_chainId`
+ * issued during lazy network detection and every call the Arbitrum SDK proxies through
+ * `provider.send` - benefits from the fallback rotation.
+ */
+export class FallbackProviderV5 extends JsonRpcProvider {
+  private endpoints: RPCEndpoint[];
+  private activeIndex = 0;
+  private emitter: EventEmitter;
+  private inner: JsonRpcProvider[] = [];
+
+  constructor(endpoints: string | (string | RPCEndpoint)[], emitter: EventEmitter) {
+    const list = Array.isArray(endpoints) ? endpoints : [endpoints];
+    const normalized = list.map((e) => (typeof e === "string" ? { url: e } : e));
+    if (normalized.length === 0) throw new Error("FallbackProviderV5 requires at least one RPC endpoint");
+    // No static network: the chainId is detected lazily through the (fallback-protected) transport.
+    super(normalized[0].url);
+    this.endpoints = normalized;
+    this.emitter = emitter;
+  }
+
+  private label(i: number) {
+    return this.endpoints[i].label ?? this.endpoints[i].url;
+  }
+
+  // Overrides the low-level transport so ALL RPC calls go through the fallback logic.
+  async send(method: string, params: Array<any>): Promise<any> {
+    let lastErr: any;
+    for (let attempt = 0; attempt < this.endpoints.length; attempt++) {
+      const i = (this.activeIndex + attempt) % this.endpoints.length;
+      try {
+        const result = await this.getInner(i).send(method, params);
+        if (i !== this.activeIndex) {
+          this.emitter.emit(BotEvents.RPC_RECOVERED, { method, from: this.label(this.activeIndex), to: this.label(i) });
+          this.activeIndex = i;
+        }
+        return result;
+      } catch (err: any) {
+        lastErr = err;
+        this.emitter.emit(BotEvents.RPC_FAILURE, {
+          method,
+          from: this.label(this.activeIndex),
+          to: this.label(i),
+          err,
+        });
+      }
+    }
+    throw lastErr;
+  }
+
+  private getInner(i: number) {
+    if (!this.inner[i]) {
+      this.inner[i] = new JsonRpcProvider(this.endpoints[i].url);
+    }
+    return this.inner[i];
+  }
+}

--- a/validator-cli/src/utils/logger.ts
+++ b/validator-cli/src/utils/logger.ts
@@ -184,4 +184,12 @@ export const configurableInitialize = (emitter: EventEmitter) => {
   emitter.on(BotEvents.FINALITY_ERROR, (message: string) => {
     logger.error({ message }, `finality_error`);
   });
+
+  // RPC fallback logs
+  emitter.on(BotEvents.RPC_FAILURE, (data) => {
+    logger.error(data, "rpc_failure");
+  });
+  emitter.on(BotEvents.RPC_RECOVERED, (data) => {
+    logger.info(data, "rpc_recovered");
+  });
 };

--- a/validator-cli/src/utils/transactionHandlers/arbToGnosisHandler.ts
+++ b/validator-cli/src/utils/transactionHandlers/arbToGnosisHandler.ts
@@ -17,6 +17,7 @@ import { ClaimNotSetError } from "../errors";
 import { getBridgeConfig, Network } from "../../consts/bridgeRoutes";
 import { getWETH, getWallet } from "../ethers";
 import { messageExecutor } from "../arbMsgExecutor";
+import { FallbackRpcProvider } from "../fallbackProvider";
 
 export class ArbToGnosisTransactionHandler extends BaseTransactionHandler<VeaInboxArbToGnosis, VeaOutboxArbToGnosis> {
   constructor(opts: BaseTransactionHandlerConstructor) {
@@ -27,9 +28,10 @@ export class ArbToGnosisTransactionHandler extends BaseTransactionHandler<VeaInb
     const { depositToken, outboxRPC, routeConfig } = getBridgeConfig(this.chainId);
     const { veaOutbox, deposit } = routeConfig[this.network];
     const privateKey = process.env.PRIVATE_KEY!;
-    const signer = getWallet(privateKey, outboxRPC);
+    const outboxProvider = new FallbackRpcProvider(outboxRPC, this.emitter, this.chainId);
+    const signer = getWallet(privateKey, outboxProvider);
 
-    const weth = getWETH(depositToken, privateKey, outboxRPC);
+    const weth = getWETH(depositToken, privateKey, outboxProvider);
     const currentAllowance: bigint = await weth.allowance(signer.address, veaOutbox.address);
     if (currentAllowance < deposit) {
       const approvalAmount = deposit * BigInt(10); // Approving for 10 claims

--- a/validator-cli/src/watcher.ts
+++ b/validator-cli/src/watcher.ts
@@ -1,6 +1,7 @@
-import { JsonRpcProvider } from "@ethersproject/providers";
 import { getBridgeConfig, Network } from "./consts/bridgeRoutes";
 import { getVeaInbox, getVeaOutbox } from "./utils/ethers";
+import { FallbackRpcProvider } from "./utils/fallbackProvider";
+import { FallbackProviderV5 } from "./utils/fallbackProviderV5";
 import { getBlockFromEpoch, setEpochRange } from "./utils/epochHandler";
 import { defaultEmitter } from "./utils/emitter";
 import { BotEvents } from "./utils/botEvents";
@@ -67,7 +68,7 @@ async function processNetwork(
     if (!toWatch[networkKey]) {
       toWatch[networkKey] = { count: -1, epochs: [] };
     }
-    const veaOutboxProvider = new JsonRpcProvider(outboxRPC);
+    const veaOutboxProvider = new FallbackProviderV5(outboxRPC, emitter);
     let veaOutboxLatestBlock = await veaOutboxProvider.getBlock("latest");
 
     // If the watcher has already started, only check the latest epoch
@@ -114,9 +115,9 @@ interface ProcessEpochParams {
   networkKey: string;
   network: Network;
   routeConfig: any;
-  inboxRPC: string;
-  outboxRPC: string;
-  routerRPC: string | undefined;
+  inboxRPC: string[];
+  outboxRPC: string[];
+  routerRPC: string[] | undefined;
   toWatch: { [key: string]: { count: number; epochs: number[] } };
   transactionHandlers: { [key: string]: any };
   emitter: typeof defaultEmitter;
@@ -136,11 +137,27 @@ async function processEpochsForNetwork({
   emitter,
 }: ProcessEpochParams) {
   const privKey = process.env.PRIVATE_KEY;
-  const veaInbox = getVeaInbox(routeConfig[network].veaInbox.address, privKey, inboxRPC, chainId, network);
-  const veaOutbox = getVeaOutbox(routeConfig[network].veaOutbox.address, privKey, outboxRPC, chainId, network);
-  const veaInboxProvider = new JsonRpcProvider(inboxRPC);
-  const veaOutboxProvider = new JsonRpcProvider(outboxRPC);
-  const veaRouterProvider = routerRPC ? new JsonRpcProvider(routerRPC) : undefined;
+  // v6 providers for the typechain contract connections (the inbox chainId is detected via the fallback transport).
+  const veaInboxContractProvider = new FallbackRpcProvider(inboxRPC, emitter);
+  const veaOutboxContractProvider = new FallbackRpcProvider(outboxRPC, emitter, chainId);
+  const veaInbox = getVeaInbox(
+    routeConfig[network].veaInbox.address,
+    privKey,
+    veaInboxContractProvider,
+    chainId,
+    network
+  );
+  const veaOutbox = getVeaOutbox(
+    routeConfig[network].veaOutbox.address,
+    privKey,
+    veaOutboxContractProvider,
+    chainId,
+    network
+  );
+  // v5 providers for the standalone reads / Arbitrum SDK path.
+  const veaInboxProvider = new FallbackProviderV5(inboxRPC, emitter);
+  const veaOutboxProvider = new FallbackProviderV5(outboxRPC, emitter);
+  const veaRouterProvider = routerRPC && routerRPC.length > 0 ? new FallbackProviderV5(routerRPC, emitter) : undefined;
   let i = toWatch[networkKey].epochs.length - 1;
   let latestEpoch = toWatch[networkKey].epochs[i];
   const currentEpoch = Math.floor(Date.now() / (1000 * routeConfig[network].epochPeriod));

--- a/validator-cli/tsconfig.json
+++ b/validator-cli/tsconfig.json
@@ -4,6 +4,7 @@
   ],
   "compilerOptions": {
     "baseUrl": ".",
+    "target": "es2021",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the RPC handling capabilities within the `validator-cli` project. It introduces a fallback mechanism for RPC endpoints, updates the TypeScript configuration, and adds new logging for RPC failures and recoveries.

### Detailed summary
- Updated `tsconfig.json` to target `es2021`.
- Added new RPC fallback states: `RPC_FAILURE` and `RPC_RECOVERED`.
- Implemented fallback RPC providers in `fallbackProvider.ts` and `fallbackProviderV5.ts`.
- Updated logging in `logger.ts` for RPC events.
- Modified several functions to accept `JsonRpcProvider` instead of RPC URLs.
- Changed `inboxRPC` and `outboxRPC` to arrays for multiple endpoints.
- Enhanced the README.md with testing instructions.
- Updated Dockerfile to use a newer Node version.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RPC configuration now supports comma-separated fallback endpoints (primary first, backups tried in order) with automatic failover.
  * Added transparent failover RPC providers for both contract access paths, including recovery/failure signaling.
* **Observability**
  * Added RPC failure/recovered event tracking and corresponding “RPC fallback” log output.
* **Documentation**
  * Documented Jest test commands in the README.
* **Chores**
  * Updated Docker Node.js image and set TypeScript target to ES2021.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->