### PR TITLE
Feat/ci docker publish

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,74 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches: [dev]
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: validator-cli
+            dockerfile: ./validator-cli/Dockerfile
+            target: validator
+            title: vea-validator-cli
+            description: "Validator bot for the Vea cross-chain bridge: saves snapshots, challenges invalid claims and advances verification"
+          - image: relayer-cli
+            dockerfile: ./relayer-cli/Dockerfile
+            target: relayer
+            title: vea-relayer-cli
+            description: "Relayer bot for the Vea cross-chain bridge: relays messages from VeaInbox to VeaOutbox and executes Hashi messages"
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository }}/${{ matrix.image }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.title }}
+            org.opencontainers.image.description=${{ matrix.description }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.licenses=MIT
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha-,format=short
+
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Per-image cache scope: both matrix legs would otherwise share the
+          # default "buildkit" scope and evict each other every run.
+          cache-from: type=gha,scope=${{ matrix.image }}
+          # mode=max also exports the builder stage, where yarn install and the
+          # contracts build happen. The default (mode=min) would only cache the
+          # final stage's layers, which is not where the slow work is.
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,13 +6,18 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
+# Declare default permissions as read only.
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      # Needed for actions/checkout to fetch code.
+      contents: read
+      # Needed to push the built images to GitHub Container Registry.
+      packages: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -12,6 +12,10 @@ permissions:
 
 jobs:
   build-and-push:
+    # workflow_dispatch has no native ref filter, so a manual run from any branch
+    # would build that branch and move :latest. The push triggers above are
+    # already ref-filtered; this restricts manual runs to the same deploy branch.
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     permissions:
       # Needed for actions/checkout to fetch code.
@@ -39,6 +43,11 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Nothing here uses git after checkout, and GHCR auth comes from
+          # docker/login-action below. Keeping the token out of .git/config also
+          # keeps it out of the Docker build context, which is the whole repo.
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,43 @@
+# Developer compose: builds the bot images from source in this working tree.
+# Operators running published images should use docker-compose.yml instead.
+#
+#   docker compose -f docker-compose.build.yml build validator
+#   docker compose -f docker-compose.build.yml up validator
+services:
+  validator:
+    build:
+      context: .
+      dockerfile: ./validator-cli/Dockerfile
+      target: validator
+    command: yarn start --saveSnapshot
+    env_file:
+      - path: ./validator-cli/.env
+        required: true
+    restart: unless-stopped
+    networks:
+      - vea-network
+
+  relayer:
+    build:
+      context: .
+      dockerfile: ./relayer-cli/Dockerfile
+      target: relayer
+    env_file:
+      - path: ./relayer-cli/.env
+        required: true
+    # Overrides STATE_DIR from .env, which defaults to a host path that does not
+    # exist in the image. Must stay in sync with the volume below: the relayer
+    # also writes its lock files to ./state relative to WORKDIR.
+    environment:
+      STATE_DIR: /home/node/monorepo/relayer-cli/state/
+    volumes:
+      - relayer-state:/home/node/monorepo/relayer-cli/state
+    restart: unless-stopped
+    networks:
+      - vea-network
+
+networks:
+  vea-network:
+
+volumes:
+  relayer-state:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
+# Operator compose: runs the images published to GitHub Container Registry by
+# .github/workflows/publish-docker.yml.
+# To build from source instead, use docker-compose.build.yml.
 services:
   validator:
-    build:
-      context: .
-      dockerfile: ./validator-cli/Dockerfile
-    command: yarn start --saveSnapshot 
+    image: ghcr.io/kleros/vea/validator-cli:latest
+    command: yarn start --saveSnapshot
     env_file:
       - path: ./validator-cli/.env
         required: true
@@ -12,14 +13,23 @@ services:
       - vea-network
 
   relayer:
-    build:
-      context: .
-      dockerfile: ./relayer-cli/Dockerfile
+    image: ghcr.io/kleros/vea/relayer-cli:latest
     env_file:
       - path: ./relayer-cli/.env
         required: true
+    # Overrides STATE_DIR from .env, which defaults to a host path that does not
+    # exist in the image. Must stay in sync with the volume below: the relayer
+    # also writes its lock files to ./state relative to WORKDIR.
+    environment:
+      STATE_DIR: /home/node/monorepo/relayer-cli/state/
+    volumes:
+      - relayer-state:/home/node/monorepo/relayer-cli/state
     restart: unless-stopped
     networks:
       - vea-network
+
 networks:
   vea-network:
+
+volumes:
+  relayer-state:

--- a/relayer-cli/README.md
+++ b/relayer-cli/README.md
@@ -63,16 +63,31 @@ yarn build
 Run relayer:
 
 ```bash
-cp .env.example .env   # fill in your values
+cp .env.dist .env      # fill in your values
 yarn start-relayer
 ```
 
 ## Docker
 
+Create the env file first (`cp .env.dist .env`) — both compose files declare it
+as required, so they fail immediately without it.
+
+Run the image published to GHCR (from the repo root):
+
 ```bash
-docker compose build relayer
 docker compose up relayer
 ```
+
+Or build it from this working tree instead:
+
+```bash
+docker compose -f docker-compose.build.yml build relayer
+docker compose -f docker-compose.build.yml up relayer
+```
+
+Both compose files set `STATE_DIR` to the in-container state directory and
+persist it in the `relayer-state` volume; the `STATE_DIR` value in `.env` is
+used only when running the relayer outside Docker.
 
 ## Tests
 

--- a/relayer-cli/README.md
+++ b/relayer-cli/README.md
@@ -69,8 +69,12 @@ yarn start-relayer
 
 ## Docker
 
-Create the env file first (`cp .env.dist .env`) — both compose files declare it
-as required, so they fail immediately without it.
+Create the env file first — both compose files declare it as required, so they
+fail immediately without it. From the repo root:
+
+```bash
+cp relayer-cli/.env.dist relayer-cli/.env
+```
 
 Run the image published to GHCR (from the repo root):
 

--- a/validator-cli/README.md
+++ b/validator-cli/README.md
@@ -6,9 +6,20 @@ A collection of bots for the Vea challenger and bridger ecosystem.
 
 # docker
 
-`docker compose build validator`
+Create the env file first — both compose files declare it as required, so they
+fail immediately without it:
+
+`cp .env.dist .env`
+
+Run the image published to GHCR (from the repo root):
 
 `docker compose up validator`
+
+Or build it from this working tree instead:
+
+`docker compose -f docker-compose.build.yml build validator`
+
+`docker compose -f docker-compose.build.yml up validator`
 
 By default, the validator performs two core functions:
 
@@ -17,17 +28,25 @@ By default, the validator performs two core functions:
 
 # flags
 
-Update Dockerfile for passing different flags
+Flags are passed as the container's command. When running the published image,
+set them on the `validator` service in the root `docker-compose.yml`:
+
+`command: yarn start --saveSnapshot --path=challenger`
+
+When building from source you can change `CMD` in `validator-cli/Dockerfile`
+instead. Outside Docker, append them to `yarn start`.
 
 `--saveSnapshot`
 
 Enables snapshot saving on the inbox when the bot observes a valid state.
 
-`--path=challenger | bridger | both`
+`--path=claimer | challenger | both`
 
+- claimer: Only submit snapshots — this is the "Bridger" role described above
 - challenger: Only challenge invalid claims
-- bridger: Only submit snapshots
-- both: Default mode, acts as both challenger and bridger
+- both: Default mode, acts as both claimer and challenger
+
+The accepted value is `claimer`, not `bridger`; `--path=bridger` throws `InvalidBotPathError`.
 
 # testing
 

--- a/validator-cli/README.md
+++ b/validator-cli/README.md
@@ -7,9 +7,9 @@ A collection of bots for the Vea challenger and bridger ecosystem.
 # docker
 
 Create the env file first — both compose files declare it as required, so they
-fail immediately without it:
+fail immediately without it. From the repo root:
 
-`cp .env.dist .env`
+`cp validator-cli/.env.dist validator-cli/.env`
 
 Run the image published to GHCR (from the repo root):
 
@@ -28,13 +28,16 @@ By default, the validator performs two core functions:
 
 # flags
 
-Flags are passed as the container's command. When running the published image,
-set them on the `validator` service in the root `docker-compose.yml`:
+Flags are passed as the container's command. Set them on the `validator` service
+in whichever compose file you use — `docker-compose.yml` for the published image,
+`docker-compose.build.yml` when building from source:
 
 `command: yarn start --saveSnapshot --path=challenger`
 
-When building from source you can change `CMD` in `validator-cli/Dockerfile`
-instead. Outside Docker, append them to `yarn start`.
+Both compose files set `command:`, which replaces the image's `CMD`, so editing
+`CMD` in `validator-cli/Dockerfile` has no effect when starting via compose; it
+applies only to a direct `docker run`. Outside Docker, append the flags to
+`yarn start`.
 
 `--saveSnapshot`
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation and Docker configurations for the `validator-cli` and `relayer-cli` services, improving clarity on environment setup and adjusting commands for building and running Docker images.

### Detailed summary
- Changed the environment file copy command in `relayer-cli/README.md` from `.env.example` to `.env.dist`.
- Added instructions for creating the `.env` file in both `relayer-cli` and `validator-cli` README files.
- Updated `docker-compose.yml` to use published images for `validator` and `relayer`.
- Added environment variable `STATE_DIR` for the `relayer` service in `docker-compose.yml`.
- Modified the `validator` service command to clarify flag usage in `validator-cli/README.md`.
- Updated the accepted values for the `--path` flag in `validator-cli/README.md`.
- Introduced a new GitHub Actions workflow in `.github/workflows/publish-docker.yml` for building and publishing Docker images.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated publishing of validator and relayer Docker images.
  * Added a local Docker Compose configuration for building and running both services from source.
  * Published-image deployments now persist relayer state through a named volume.
  * Docker Compose deployments support published images or local builds.

* **Documentation**
  * Updated Docker setup instructions for environment files, image workflows, command overrides, and persistent state storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->